### PR TITLE
feat: adds CurrentContextProviderInterface

### DIFF
--- a/src/Contracts/CurrentContextProviderInterface.php
+++ b/src/Contracts/CurrentContextProviderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use Exception;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+interface CurrentContextProviderInterface
+{
+    /**
+     * @throws Exception When there is no current Procedure
+     */
+    public function getCurrentProcedure(): ProcedureInterface;
+
+    /**
+     * @throws Exception When there is no current User
+     */
+    public function getCurrentUser(): UserInterface;
+
+    /**
+     * @throws Exception When there is no current Customer
+     */
+    public function getCurrentCustomer(): CustomerInterface;
+}


### PR DESCRIPTION
This is meant as a single provider for all relevant and available context information for addons. In the next step, we need to remove the individual interface for current customer/user/procedure so that it is only one source of truth.