### PR TITLE
fix: allow interfaces in `@property-read` tags

### DIFF
--- a/src/Contracts/ResourceType/AddonDocblockPropertyByTraitEvaluator.php
+++ b/src/Contracts/ResourceType/AddonDocblockPropertyByTraitEvaluator.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DemosEurope\DemosplanAddon\Contracts\ResourceType;
+
+use EDT\PathBuilding\DocblockPropertyByTraitEvaluator;
+use EDT\PathBuilding\TraitEvaluator;
+use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlock\Tags\Param;
+use phpDocumentor\Reflection\DocBlock\Tags\Property;
+use phpDocumentor\Reflection\DocBlock\Tags\PropertyRead;
+use phpDocumentor\Reflection\DocBlock\Tags\PropertyWrite;
+use phpDocumentor\Reflection\DocBlock\Tags\TagWithType;
+use phpDocumentor\Reflection\DocBlock\Tags\Var_;
+use function Safe\array_combine;
+
+/**
+ * @deprecated This class is only needed temporary to fix a bug in a third-party dependency. After the
+ * `demos-europe/edt-...` dependencies has been updated to `^0.17`, this class can be removed.
+ */
+class AddonDocblockPropertyByTraitEvaluator extends DocblockPropertyByTraitEvaluator
+{
+    private TraitEvaluator $traitEvaluator;
+    private array $parsedClasses = [];
+    private array $targetTags;
+
+    public function __construct(
+        TraitEvaluator $traitEvaluator,
+        string $targetTrait,
+        array $targetTags
+    ) {
+        parent::__construct($traitEvaluator, $targetTrait, $targetTags);
+        $this->traitEvaluator = $traitEvaluator;
+        $this->targetTags = $targetTags;
+    }
+
+    public function parseProperties(string $class, bool $includeParents = false): array
+    {
+        if ($includeParents) {
+            $classes = $this->traitEvaluator->getAllParents($class);
+            array_unshift($classes, $class);
+        } else {
+            $classes = [$class];
+        }
+
+        return $this->parsePropertiesOfClasses($classes);
+    }
+
+    private function parsePropertiesOfClasses(array $classes): array
+    {
+        $nestedPropertiesByClass = array_map([$this, 'parsePropertiesOfClass'], $classes);
+
+        return array_merge(...array_reverse($nestedPropertiesByClass));
+    }
+
+    private function parsePropertiesOfClass(string $class): array
+    {
+        if (!array_key_exists($class, $this->parsedClasses)) {
+            $parser = new AddonDocblockTagParser($class);
+            $nestedProperties = array_map(function (string $targetTag) use ($parser): array {
+                $tags = $parser->getTags($targetTag);
+                $tags = array_map(static function (Tag $tag): TagWithType {
+                    if (!$tag instanceof PropertyRead
+                        && !$tag instanceof PropertyWrite
+                        && !$tag instanceof Property
+                        && !$tag instanceof Param
+                        && !$tag instanceof Var_) {
+                        throw new \InvalidArgumentException("Can not determine variable name for '{$tag->getName()}' tags.");
+                    }
+
+                    return $tag;
+                }, $tags);
+                $keys = array_map([$parser, 'getVariableNameOfTag'], $tags);
+                $tags = array_combine($keys, $tags);
+                $tags = array_map([$parser, 'getTagType'], $tags);
+
+                return $tags;
+            }, $this->targetTags);
+
+            $this->parsedClasses[$class] = array_merge(...$nestedProperties);
+        }
+
+        return $this->parsedClasses[$class];
+    }
+}

--- a/src/Contracts/ResourceType/AddonDocblockTagParser.php
+++ b/src/Contracts/ResourceType/AddonDocblockTagParser.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DemosEurope\DemosplanAddon\Contracts\ResourceType;
+
+use EDT\Parsing\Utilities\DocblockTagParser;
+use EDT\Parsing\Utilities\TagTypeParseException;
+use EDT\Parsing\Utilities\UseCollector;
+use phpDocumentor\Reflection\DocBlock\Tags\TagWithType;
+use phpDocumentor\Reflection\Types\AggregatedType;
+use phpDocumentor\Reflection\Types\Object_;
+use PhpParser\NodeTraverser;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use ReflectionClass;
+use function Safe\fclose;
+use function Safe\fopen;
+
+/**
+ * @deprecated This class is only needed temporary to fix a bug in a third-party dependency. After the
+ * `demos-europe/edt-...` dependencies has been updated to `^0.17`, this class can be removed.
+ */
+class AddonDocblockTagParser extends DocblockTagParser
+{
+    private ReflectionClass $reflectionClass;
+    private array $useStatements;
+    private Parser $phpParser;
+
+    public function __construct(string $class)
+    {
+        parent::__construct($class);
+        $this->phpParser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $this->reflectionClass = new ReflectionClass($class);
+        $this->useStatements = $this->getUseStatements();
+
+    }
+
+    public function getTagType(TagWithType $tag): string
+    {
+        $namespaceName = $this->reflectionClass->getNamespaceName();
+
+        return $this->getFqsenOfClass($tag, $namespaceName);
+    }
+
+    private function getFqsenOfClass(TagWithType $tag, string $namespaceName): string
+    {
+        $tagType = $tag->getType();
+        if ($tagType instanceof AggregatedType) {
+            throw TagTypeParseException::createForAggregatedType($tag, $tagType, $this->reflectionClass->getName());
+        }
+        if (!$tagType instanceof Object_) {
+            // not even an object as return type
+            throw TagTypeParseException::createForTagType($tag, (string)$tagType, $this->reflectionClass->getName());
+        }
+
+        $typeDeclaration = (string)$tagType->getFqsen();
+        $fqsenParts = explode('\\', $typeDeclaration);
+        if (2 > count($fqsenParts)) {
+            throw TagTypeParseException::createForTagType($tag, (string)$tagType, $this->reflectionClass->getName());
+        }
+
+        // look for return type in use statements
+        $class = $fqsenParts[1];
+        $fqsen = null;
+        foreach ($this->useStatements as $as => $currentUseFqsen) {
+            if ($class === $as) {
+                $fqsen = $currentUseFqsen;
+                break;
+            }
+        }
+
+        if (null !== $fqsen && (class_exists($fqsen) || interface_exists($fqsen))) {
+            // usable return type found in use statements
+            return $fqsen;
+        }
+
+        if (class_exists($typeDeclaration) || interface_exists($typeDeclaration)) {
+            // the declaration was a valid FQSEN in the first place
+            return $typeDeclaration;
+        }
+
+        // no matching 'use' statements were found and the class is not already defined
+        // with a FQSEN. Adding the current namespace as last resort to find it.
+        $fqsen = $namespaceName.$typeDeclaration;
+        if (class_exists($fqsen) || interface_exists($fqsen)) {
+            // usable return type found in use statements
+            return $fqsen;
+        }
+
+        // giving up looking for return type
+        throw TagTypeParseException::createForTagType($tag, (string)$tagType, $this->reflectionClass->getName());
+    }
+
+    private function getUseStatements(): array
+    {
+        $fileName = $this->reflectionClass->getFileName();
+        if (!is_string($fileName)) {
+            /**
+             * In some cases no source code can be retrieved for the given type (e.g.
+             * {@link IteratorAggregate}). For now we will assume it does not happen for with
+             * "normal" types and ignore it until it becomes a problem in an actual use case.
+             */
+            return [];
+        }
+        $sourceCode = $this->readSourceCode($fileName);
+        $ast = $this->phpParser->parse($sourceCode);
+        $traverser = new NodeTraverser();
+        $useCollector = new UseCollector();
+        $traverser->addVisitor($useCollector);
+        $traverser->traverse($ast);
+
+        return $useCollector->getUseStatements();
+    }
+
+    private function readSourceCode(string $fileName): string
+    {
+        $file = fopen($fileName, 'r');
+        $lineNumber = 0;
+        $sourceCode = '';
+
+        while (!feof($file)) {
+            $lineNumber += 1;
+
+            if ($lineNumber >= $this->reflectionClass->getStartLine()) {
+                break;
+            }
+
+            $line = fgets($file);
+            if (false === $line) {
+                throw new \InvalidArgumentException("Failed to read source code of file: '$fileName' in line $lineNumber.");
+            }
+            $sourceCode .= $line;
+        }
+
+        fclose($file);
+
+        return $sourceCode;
+    }
+}

--- a/src/Contracts/ResourceType/AddonResourceType.php
+++ b/src/Contracts/ResourceType/AddonResourceType.php
@@ -12,9 +12,11 @@ use EDT\ConditionFactory\ConditionFactoryInterface;
 use EDT\JsonApi\RequestHandling\MessageFormatter;
 use EDT\JsonApi\ResourceTypes\CachingResourceType;
 use EDT\JsonApi\ResourceTypes\ResourceTypeInterface;
+use EDT\PathBuilding\DocblockPropertyByTraitEvaluator;
 use EDT\PathBuilding\End;
 use EDT\PathBuilding\PropertyAutoPathInterface;
 use EDT\PathBuilding\PropertyAutoPathTrait;
+use EDT\PathBuilding\TraitEvaluator;
 use EDT\Querying\Contracts\PropertyPathInterface;
 use EDT\Wrapping\Contracts\TypeProviderInterface;
 use EDT\Wrapping\Contracts\Types\TypeInterface;
@@ -147,6 +149,23 @@ abstract class AddonResourceType extends CachingResourceType implements Iterator
             })->all();
     }
 
+    /**
+     * @deprecated This method is only needed temporary to fix a bug in a third-party dependency. After the
+     * `demos-europe/edt-...` dependencies has been updated to `^0.17`, this method can be removed.
+     */
+    protected function getDocblockTraitEvaluator(array $targetTags): DocblockPropertyByTraitEvaluator
+    {
+        if (null === $this->docblockTraitEvaluator) {
+            $this->docblockTraitEvaluator = new AddonDocblockPropertyByTraitEvaluator(
+                new TraitEvaluator(),
+                PropertyAutoPathTrait::class,
+                $targetTags,
+            );
+        }
+
+        return $this->docblockTraitEvaluator;
+    }
+
     protected function processProperties(array $properties): array
     {
         return $properties;
@@ -172,4 +191,3 @@ abstract class AddonResourceType extends CachingResourceType implements Iterator
         return $this->messageFormatter;
     }
 }
-


### PR DESCRIPTION
It is currently not possible to update the dependencies to `demos-europe/edt-...` version `^0.17`, which contains a fix to allow for the parsing of `@property-read` docblock tags with an interface as type.

As a workaround, the `getFqsenOfClass` method was copied and adjusted accordingly. However, this required some code duplication, as most classes and methods in the call hierarchy of `getFqsenOfClass` are set to private.

The workaround is assumed to be short-lived, as updating to `^0.17` has a high priority. Afterwards the classes can be removed. The `getDocblockTraitEvaluator` method can be reverted back to the parent implementation, but instead of `PropertyAutoPathTrait::class` as required trait an empty array needs to be passed, as interfaces can't use traits.