### PR TITLE
feat: add parameter honeypotTimeout to configure the timeout

### DIFF
--- a/src/Contracts/Config/GlobalConfigInterface.php
+++ b/src/Contracts/Config/GlobalConfigInterface.php
@@ -147,6 +147,8 @@ interface GlobalConfigInterface
 
     public function isHoneypotDisabled(): bool;
 
+    public function getHoneypotTimeout(): int;
+
     public function getMaintenanceKey(): string;
 
     /**


### PR DESCRIPTION
This PR adds a new interface method to retrieve the honeypot timeout, that was introduced in https://github.com/demos-europe/demosplan-core/pull/293