### PR TITLE
feature: enable logging of all API exceptions

### DIFF
--- a/src/Controller/APIController.php
+++ b/src/Controller/APIController.php
@@ -252,9 +252,7 @@ abstract class APIController extends AbstractController
         $status = Response::HTTP_BAD_REQUEST;
         $message = '';
 
-        if (!$this->globalConfig->isProdMode()) {
-            $this->logger->error('API exception occurred', [$exception]);
-        }
+        $this->logger->error('API exception occurred', [$exception]);
 
         try {
             switch (true) {


### PR DESCRIPTION
The reason why a6f88207 added logging for non-prod mode only is unknown. It may have been to avoid
logging sensitive user data. This however is no longer deemed (enough) reason to disable the logging.