### PR TITLE
feature (refs T30254) This method is not needed and can therefore be removed

### DIFF
--- a/src/Contracts/PercentageDistributionTransformerInterface.php
+++ b/src/Contracts/PercentageDistributionTransformerInterface.php
@@ -6,5 +6,5 @@ namespace DemosEurope\DemosplanAddon\Contracts;
 
 interface PercentageDistributionTransformerInterface
 {
-    public function getInstance();
+
 }


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T30254

Description:
This method is not needed and can therefore be removed
Its Implementation got removed here: https://github.com/demos-europe/demosplan-core/pull/1116
And the usage got removed here: https://github.com/demos-europe/demosplan-addon-demospipes/pull/61