### PR TITLE
feature (refs T32212) add methods to interfaces / add new necessary interfaces

### DIFF
--- a/src/Contracts/ApiRequest/ApiResourceServiceInterface.php
+++ b/src/Contracts/ApiRequest/ApiResourceServiceInterface.php
@@ -4,7 +4,57 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\ApiRequest;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\CoreEntityInterface;
+use DemosEurope\DemosplanAddon\Contracts\ValueObject\ValueObjectInterface;
+use DemosEurope\DemosplanAddon\Logic\ApiRequest\Transformer\BaseTransformerInterface;
+use Exception;
+use League\Fractal\Manager;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use Symfony\Component\Security\Core\User\UserInterface;
+
 interface ApiResourceServiceInterface
 {
+    public function getFractal(): Manager;
 
+    /**
+     * @param string $transformerName #Service Service name or fq class name of the transformer
+     *
+     * @throws Exception
+     */
+    public function getTransformer(string $transformerName): BaseTransformerInterface;
+
+    /**
+     * @param iterable|CoreEntityInterface[]|ValueObjectInterface[] $data
+     * @param string $transformerName #Service Service name or fq class name of the transformer
+     * @param string $type optionally override the item type
+     */
+    public function makeCollection($data, string $transformerName, $type = ''): Collection;
+
+    /**
+     * @param                           $data
+     * @param BaseTransformerInterface  $baseTransformer
+     * @param                           $type
+     *
+     * @return Collection
+     */
+    public function makeAddonCollection($data, BaseTransformerInterface $baseTransformer, $type = ''): Collection;
+
+    /**
+     * @param iterable|CoreEntityInterface[]|ValueObjectInterface[] $data
+     * @param string $resourceTypeName The value returned by {@link ResourceTypeInterface::getName()}
+     */
+    public function makeCollectionOfResources($data, string $resourceTypeName): Collection;
+
+    /**
+     * @param array|CoreEntityInterface|ValueObjectInterface|UserInterface $data
+     * @param string $transformerName #Service name or fq class name of the transformer
+     * @param string $type optionally override the item type
+     */
+    public function makeItem($data, string $transformerName, $type = ''): Item;
+
+    /**
+     * @param string $resourceTypeName The value returned by {@link ResourceTypeInterface::getName()}
+     */
+    public function makeItemOfResource($data, string $resourceTypeName): Item;
 }

--- a/src/Contracts/Entities/AddressBookEntryInterface.php
+++ b/src/Contracts/Entities/AddressBookEntryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface AddressBookEntryInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/AddressBookEntryInterface.php
+++ b/src/Contracts/Entities/AddressBookEntryInterface.php
@@ -2,7 +2,39 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+
 interface AddressBookEntryInterface extends UuidEntityInterface
 {
+    public function getName(): ?string;
 
+    /**
+     * @param string|null $name
+     */
+    public function setName($name);
+
+    public function getEmailAddress(): string;
+
+    public function setEmailAddress(string $emailAddress);
+
+    /**
+     * @return DateTime|DateTimeImmutable
+     */
+    public function getCreatedDate(): DateTimeInterface;
+
+    /**
+     * @param DateTime|DateTimeImmutable $createdDate
+     */
+    public function setCreatedDate(DateTimeInterface $createdDate);
+
+    /**
+     * @return DateTime|DateTimeImmutable
+     */
+    public function getModifiedDate(): DateTimeInterface;
+
+    public function getOrganisation(): OrgaInterface;
+
+    public function setOrganisation(OrgaInterface $organisation);
 }

--- a/src/Contracts/Entities/AddressInterface.php
+++ b/src/Contracts/Entities/AddressInterface.php
@@ -2,7 +2,72 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use DateTime;
+use DateTimeInterface;
+
 interface AddressInterface extends UuidEntityInterface
 {
+    public function setCode(?string $code): self;
 
+    public function getCode(): ?string;
+
+    public function setStreet(?string $street): self;
+
+    public function getStreet(): string;
+
+    public function setStreet1(?string $street1): self;
+
+    public function getStreet1(): ?string;
+
+    public function setPostalcode(?string $postalcode): self;
+
+    public function getPostalcode(): string;
+
+    public function setCity(?string $city): self;
+
+    public function getCity(): string;
+
+    public function setRegion(?string $region): self;
+
+    public function getRegion(): ?string;
+
+    public function setState(?string $state): self;
+
+    public function getState(): ?string;
+
+    public function setPostofficebox(?string $postofficebox): self;
+
+    public function getPostofficebox(): ?string;
+
+    public function setPhone(?string $phone): self;
+
+    public function getPhone(): ?string;
+
+    public function setFax(?string $fax): self;
+
+    public function getFax(): ?string;
+
+    public function setEmail(?string $email): self;
+
+    public function getEmail(): ?string;
+
+    public function setUrl(?string $url): self;
+
+    public function getUrl(): ?string;
+
+    public function setCreatedDate(DateTimeInterface $createdDate): self;
+
+    public function getCreatedDate(): DateTime;
+
+    public function setModifiedDate(DateTimeInterface $modifiedDate): self;
+
+    public function getModifiedDate(): DateTime;
+
+    public function setDeleted(bool $deleted): self;
+
+    public function getDeleted(): bool;
+
+    public function getHouseNumber(): string;
+
+    public function setHouseNumber(string $houseNumber): void;
 }

--- a/src/Contracts/Entities/AddressInterface.php
+++ b/src/Contracts/Entities/AddressInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface AddressInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/BrandingInterface.php
+++ b/src/Contracts/Entities/BrandingInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface BrandingInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/BrandingInterface.php
+++ b/src/Contracts/Entities/BrandingInterface.php
@@ -4,5 +4,11 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 interface BrandingInterface extends UuidEntityInterface
 {
+    public function getCssvars(): ?string;
 
+    public function setCssvars(?string $cssVars): self;
+
+    public function getLogo(): ?FileInterface;
+
+    public function setLogo(?FileInterface $logo): void;
 }

--- a/src/Contracts/Entities/ContextualHelpInterface.php
+++ b/src/Contracts/Entities/ContextualHelpInterface.php
@@ -4,7 +4,70 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use DateTime;
+
 interface ContextualHelpInterface extends UuidEntityInterface
 {
+    /**
+     * Set ident.
+     *
+     * @param string|null $ident
+     *
+     * @return ContextualHelpInterface
+     */
+    public function setIdent($ident);
 
+    /**
+     * Set key.
+     *
+     * @param string $key
+     *
+     * @return ContextualHelpInterface
+     */
+    public function setKey($key);
+
+    /**
+     * get key.
+     *
+     * @return string
+     */
+    public function getKey();
+
+    /**
+     * Set text.
+     *
+     * @param string $text
+     *
+     * @return ContextualHelpInterface
+     */
+    public function setText($text);
+
+    /**
+     * @return string
+     */
+    public function getText();
+
+    /**
+     * @param DateTime $createDate
+     *
+     * @return ContextualHelpInterface
+     */
+    public function setCreateDate($createDate);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreateDate();
+
+    /**
+     * @param DateTime $modifyDate
+     *
+     * @return ContextualHelpInterface
+     */
+    public function setModifyDate($modifyDate);
+
+    /**
+     * @return DateTime
+     */
+    public function getModifyDate();
 }

--- a/src/Contracts/Entities/CoreEntityInterface.php
+++ b/src/Contracts/Entities/CoreEntityInterface.php
@@ -6,5 +6,13 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 interface CoreEntityInterface
 {
-
+    /**
+     * The Database field to store content change of an Entity, is modeled as "text".
+     * Therefore string, int or bool can be (casted and) stored.
+     *
+     * At least the ID of the object will be returned.
+     *
+     * @return string|int|bool
+     */
+    public function getEntityContentChangeIdentifier();
 }

--- a/src/Contracts/Entities/DepartmentInterface.php
+++ b/src/Contracts/Entities/DepartmentInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface DepartmentInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/DepartmentInterface.php
+++ b/src/Contracts/Entities/DepartmentInterface.php
@@ -2,7 +2,153 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface DepartmentInterface extends UuidEntityInterface
-{
+use DateTime;
+use DateTimeInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Tightenco\Collect\Support\Collection;
 
+interface DepartmentInterface extends UuidEntityInterface, CoreEntityInterface
+{
+    /**
+     * For technical reasons, a department is always required, even if none is given.
+     * This is the default name.
+     */
+    public const DEFAULT_DEPARTMENT_NAME = 'Keine Abteilung';
+
+    public function setId(string $id): void;
+
+    /**
+     * @return DepartmentInterface
+     */
+    public function setName(string $name);
+
+    public function getName(): string;
+
+    /**
+     * @param string $code
+     *
+     * @return DepartmentInterface
+     */
+    public function setCode($code);
+
+    /**
+     * @return string
+     */
+    public function getCode();
+
+    /**
+     * @param DateTime $createdDate
+     *
+     * @return DepartmentInterface
+     */
+    public function setCreatedDate(DateTimeInterface $createdDate);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedDate();
+
+    /**
+     * @param DateTime $modifiedDate
+     *
+     * @return DepartmentInterface
+     */
+    public function setModifiedDate(DateTimeInterface $modifiedDate);
+
+    /**
+     * @return DateTime
+     */
+    public function getModifiedDate();
+
+    /**
+     * @param bool $deleted
+     *
+     * @return DepartmentInterface
+     */
+    public function setDeleted($deleted);
+
+    /**
+     * @return bool
+     */
+    public function getDeleted();
+
+    /**
+     * @return bool
+     */
+    public function isDeleted();
+
+    /**
+     * @param string|null $gwId
+     *
+     * @return DepartmentInterface
+     */
+    public function setGwId($gwId);
+
+    /**
+     * @return string|null
+     */
+    public function getGwId();
+
+    /**
+     * Organisation des Departments.
+     *
+     * @return OrgaInterface|null
+     */
+    public function getOrga();
+
+    /**
+     * Will return an empty string, if no Orga is set.
+     *
+     * @return string
+     */
+    public function getOrgaName();
+
+    /**
+     * Add Orga to this Department.
+     */
+    public function addOrga(OrgaInterface $orga);
+
+    /**
+     * @return AddressInterface
+     */
+    public function getAddress();
+
+    /**
+     * @return ArrayCollection<int,AddressInterface>
+     */
+    public function getAddresses(): self;
+
+    /**
+     * Add Address to Orga.
+     *
+     * @param AddressInterface $address
+     */
+    public function addAddress($address);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getAllUsers();
+
+    /**
+     * Returns all users of this department, which are not deleted === true.
+     *
+     * @return Collection<int,UserInterface>
+     */
+    public function getUsers();
+
+    /**
+     * @param array<int,UserInterface> $users
+     */
+    public function setUsers($users): self;
+
+    /**
+     * Add user to this Department, if not already exists in the collection.
+     */
+    public function addUser(UserInterface $user);
+
+    /**
+     * Remove user from Department.
+     */
+    public function removeUser(UserInterface $user);
 }

--- a/src/Contracts/Entities/DepartmentInterface.php
+++ b/src/Contracts/Entities/DepartmentInterface.php
@@ -116,7 +116,7 @@ interface DepartmentInterface extends UuidEntityInterface, CoreEntityInterface
     /**
      * @return ArrayCollection<int,AddressInterface>
      */
-    public function getAddresses(): self;
+    public function getAddresses();
 
     /**
      * Add Address to Orga.

--- a/src/Contracts/Entities/ElementsInterface.php
+++ b/src/Contracts/Entities/ElementsInterface.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface ElementsInterface
+use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+interface ElementsInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const ELEMENTS_CATEGORY_MAP = 'map'; // like "Planzeichnung"
     public const ELEMENTS_CATEGORY_STATEMENT = 'statement'; // like "Gesamtstellungnahme" or "Fehlanzeige"
@@ -28,4 +32,147 @@ interface ElementsInterface
     public const FILE_TYPE_VERORDNUNG = 'Verordnung';
     public const FILE_TYPE_VERTEILER = 'Verteiler';
     public const STATEMENT_TYPE_FEHLANZEIGE = 'Fehlanzeige';
+
+    /**
+     * The maximum number of parents (technically) allowed when nesting {@link ElementsInterface} entities.
+     *
+     * E.g. `0` and smaller values would mean that no nesting of {@link ElementsInterface} entities is
+     * allowed. This value can be increased/decreased if necessary but before that look up and
+     * understand its usage, as it has performance implications.
+     */
+    public const MAX_PARENTS_COUNT = 10;
+
+    /**
+     * Set parent ElementId.
+     */
+    public function setElementParentId(?string $parentId): self;
+
+    /**
+     * Set parent element.
+     *
+     * @param ElementsInterface|null $parent
+     */
+    public function setParent(?ElementsInterface $parent): void;
+
+    /**
+     * Get parent element.
+     */
+    public function getParent(): ?ElementsInterface;
+
+    /**
+     * Get the Id of the related ParentElement.
+     */
+    public function getElementParentId(): ?string;
+
+    /**
+     * Set procedureId named pId.
+     */
+    public function setPId(string $pId): self;
+
+    public function getProcedure(): ProcedureInterface;
+
+    public function setProcedure(ProcedureInterface $procedure): self;
+
+    public function setCategory(string $category): self;
+
+    public function getCategory(): string;
+
+    public function setTitle(string $title): self;
+
+    public function getTitle(): string;
+
+    public function setIcon(string $icon): self;
+
+    public function getIcon(): string;
+
+    public function setText(string $text): self;
+
+    public function getText(): string;
+
+    public function getFile(): string;
+
+    public function setFile(string $file): void;
+
+    public function setOrder(int $order): self;
+
+    public function getOrder(): int;
+
+    public function setEnabled(bool $enabled): self;
+
+    public function getEnabled(): bool;
+
+    public function setDeleted(bool $deleted): self;
+
+    public function getDeleted(): bool;
+
+    public function setCreateDate(DateTime $createDate): self;
+
+    public function getCreateDate(): DateTime;
+
+    public function setModifyDate(DateTime $modifyDate): self;
+
+    public function getModifyDate(): DateTime;
+
+    public function setDeleteDate(DateTime $deleteDate): self;
+
+    public function getDeleteDate(): DateTime;
+
+    /**
+     * @return ArrayCollection|SingleDocumentInterface[]
+     */
+    public function getDocuments(): Collection;
+
+    /**
+     * @param ArrayCollection $documents
+     */
+    public function setDocuments(Collection $documents): void;
+
+    /**
+     * @return Collection<int,ElementsInterface>|ElementsInterface[]
+     */
+    public function getChildren(): Collection;
+
+    /**
+     * @param ArrayCollection $children
+     */
+    public function setChildren(Collection $children): void;
+
+    /**
+     * @return Collection<int,OrgaInterface>|OrgaInterface[]
+     */
+    public function getOrganisations(): Collection;
+
+    /**
+     * @param Collection<int, OrgaInterface> $organisations
+     */
+    public function setOrganisations(Collection $organisations): void;
+
+    public function addOrganisation(OrgaInterface $organisation): void;
+
+    public function removeOrganisation(OrgaInterface $organisation): void;
+
+    public function getDesignatedSwitchDate(): ?DateTime;
+
+    public function setDesignatedSwitchDate(?DateTime $designatedSwitchDate): void;
+
+    public function getIconTitle(): string;
+
+    public function setIconTitle(string $iconTitle): void;
+
+    /**
+     * This method will lead to an endless loop if an element can be have a child which have this element as a child.
+     *
+     * @return int - number of child elements including all children of children
+     */
+    public function countChildrenRecursively(): int;
+
+    public function getPermission(): ?string;
+
+    public function hasPermission(?string $permissionString): bool;
+
+    /**
+     * Will replace incoming empty string with null.
+     */
+    public function setPermission(string $permission): void;
+
 }

--- a/src/Contracts/Entities/EmailAddressInterface.php
+++ b/src/Contracts/Entities/EmailAddressInterface.php
@@ -4,7 +4,19 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface EmailAddressInterface
+interface EmailAddressInterface extends CoreEntityInterface, UuidEntityInterface
 {
+    public function setId(string $id): void;
 
+    /**
+     * The full email address containing the local part and domain name.
+     * Not the so-called display name.
+     **/
+    public function getFullAddress(): string;
+
+    /**
+    * The full email address containing the local part and domain name.
+    * Not the so-called display name.
+    **/
+    public function setFullAddress(string $fullAddress);
 }

--- a/src/Contracts/Entities/FileInterface.php
+++ b/src/Contracts/Entities/FileInterface.php
@@ -4,7 +4,227 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface FileInterface
-{
+use DateTime;
+use Exception;
 
+interface FileInterface extends UuidEntityInterface, CoreEntityInterface
+{
+    /**
+     * This ident is used in filestrings to reference to the file entity.
+     *
+     * @param string $ident
+     *
+     * @return FileInterface
+     */
+    public function setIdent($ident);
+
+    /**
+     * @deprecated use {@link FileInterface::getId()} instead
+     */
+    public function getIdent(): ?string;
+
+    /**
+     * @param string $hash
+     *
+     * @return FileInterface
+     */
+    public function setHash($hash);
+
+    /**
+     * @return string
+     */
+    public function getHash();
+
+    /**
+     * @param string $description
+     *
+     * @return FileInterface
+     */
+    public function setDescription($description);
+
+    /**
+     * @return string
+     */
+    public function getDescription();
+
+    /**
+     * @param string $path
+     *
+     * @return FileInterface
+     */
+    public function setPath($path);
+
+    /**
+     * @return string
+     */
+    public function getPath();
+
+    /**
+     * @return string the path to the file including the hash (which is the filename)
+     *
+     * @throws Exception Thrown if the hash for this instance is
+     * not a string, is an empty string, equals '..' or contains a slash ('/').
+     */
+    public function getFilePathWithHash(): string;
+
+    /**
+     * @return FileInterface
+     */
+    public function setFilename(?string $filename);
+
+    public function getFilename(): string;
+
+    public function getProcedure(): ?ProcedureInterface;
+
+    public function setProcedure(ProcedureInterface $procedure): void;
+
+    /**
+     * @param string $tags
+     *
+     * @return FileInterface
+     */
+    public function setTags($tags);
+
+    /**
+     * @return string
+     */
+    public function getTags();
+
+    /**
+     * @param string $author
+     *
+     * @return FileInterface
+     */
+    public function setAuthor($author);
+
+    /**
+     * @return string|null
+     */
+    public function getAuthor();
+
+    /**
+     * @param string $application
+     *
+     * @return FileInterface
+     */
+    public function setApplication($application);
+
+    /**
+     * @return string
+     */
+    public function getApplication();
+
+    /**
+     * @param string $mimetype
+     *
+     * @return FileInterface
+     */
+    public function setMimetype($mimetype);
+
+    /**
+     * @return string
+     */
+    public function getMimetype();
+
+    public function getSize(): int;
+
+    public function setSize(int $size);
+
+    /**
+     * @param DateTime $created
+     *
+     * @return FileInterface
+     */
+    public function setCreated($created);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreated();
+
+    /**
+     * @param DateTime $modified
+     *
+     * @return FileInterface
+     */
+    public function setModified($modified);
+
+    /**
+     * @return DateTime
+     */
+    public function getModified();
+
+    /**
+     * @param DateTime $validUntil
+     *
+     * @return FileInterface
+     */
+    public function setValidUntil($validUntil);
+
+    /**
+     * @return DateTime
+     */
+    public function getValidUntil();
+
+    /**
+     * @param bool $deleted
+     *
+     * @return FileInterface
+     */
+    public function setDeleted($deleted);
+
+    public function getDeleted(): bool;
+
+    /**
+     * @param int $statDown
+     *
+     * @return FileInterface
+     */
+    public function setStatDown($statDown);
+
+    /**
+     * @return int
+     */
+    public function getStatDown();
+
+    /**
+     * @param bool $infected
+     *
+     * @return FileInterface
+     */
+    public function setInfected($infected);
+
+    /**
+     * @return bool
+     */
+    public function getInfected();
+
+    /**
+     * @param DateTime $lastVScan
+     *
+     * @return FileInterface
+     */
+    public function setLastVScan($lastVScan);
+
+    /**
+     * @return DateTime
+     */
+    public function getLastVScan();
+
+    /**
+     * @param bool $blocked
+     *
+     * @return FileInterface
+     */
+    public function setBlocked($blocked);
+
+    /**
+     * @return bool
+     */
+    public function getBlocked();
+
+    /**
+     * Build a string of file information used in legacy context.
+     */
+    public function getFileString(): string;
 }

--- a/src/Contracts/Entities/GisLayerCategoryInterface.php
+++ b/src/Contracts/Entities/GisLayerCategoryInterface.php
@@ -4,7 +4,130 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface GisLayerCategoryInterface extends UuidEntityInterface
-{
+use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use Exception;
 
+interface GisLayerCategoryInterface extends UuidEntityInterface, CoreEntityInterface
+{
+    /**
+     * @param string $id
+     */
+    public function setId($id);
+
+    /**
+     * @return ProcedureInterface
+     */
+    public function getProcedure();
+
+    /**
+     * @param ProcedureInterface $procedure
+     */
+    public function setProcedure($procedure);
+
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @param string $name
+     */
+    public function setName($name);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreateDate();
+
+    /**
+     * @return DateTime
+     */
+    public function getModifyDate();
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getGisLayers();
+
+    /**
+     * @param GisLayerInterface[] $gisLayers
+     */
+    public function setGisLayers(array $gisLayers);
+
+    public function addLayer(GisLayerInterface $gisLayer): void;
+
+    /**
+     * @return int
+     */
+    public function getTreeOrder();
+
+    /**
+     * @param int $treeOrder
+     */
+    public function setTreeOrder($treeOrder);
+
+    /**
+     * @return GisLayerCategoryInterface
+     */
+    public function getParent();
+
+    /**
+     * @return string|null
+     */
+    public function getParentId();
+
+    /**
+     * @throws Exception
+     *
+     * @param GisLayerCategoryInterface $newParent
+     */
+    public function setParent($newParent);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getChildren();
+
+    /**
+     * @throws Exception
+     *
+     * @param GisLayerCategoryInterface[] $children
+     */
+    public function setChildren($children);
+
+    /**
+     * @return bool
+     */
+    public function isVisible();
+
+    /**
+     * @param bool $visible
+     */
+    public function setVisible($visible);
+
+    /**
+     * @return bool
+     */
+    public function isRoot();
+
+    /**
+     * @param DateTime $createDate
+     */
+    public function setCreateDate($createDate);
+
+    /**
+     * @param DateTime $modifyDate
+     */
+    public function setModifyDate($modifyDate);
+
+    /**
+     * @return bool
+     */
+    public function isLayerWithChildrenHidden();
+
+    /**
+     * @param bool $layerWithChildrenHidden
+     */
+    public function setLayerWithChildrenHidden($layerWithChildrenHidden);
 }

--- a/src/Contracts/Entities/InstitutionTagInterface.php
+++ b/src/Contracts/Entities/InstitutionTagInterface.php
@@ -2,7 +2,33 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use DateTime;
+use Doctrine\Common\Collections\Collection;
+
 interface InstitutionTagInterface extends UuidEntityInterface
 {
+    public function getOwningOrganisation(): OrgaInterface;
 
+    /**
+     * @return Collection<int, OrgaInterface>
+     */
+    public function getTaggedInstitutions(): Collection;
+
+    /**
+     * @param Collection<int, OrgaInterface> $institutions
+     */
+    public function setTaggedInstitutions(Collection $institutions): void;
+
+    public function getCreationDate(): DateTime;
+
+    public function getModificationDate(): DateTime;
+
+    /**
+     * @return bool - true if the given statement was added to this tag, otherwise false
+     */
+    public function addTaggedInstitution(OrgaInterface $institution): bool;
+
+    public function getLabel(): string;
+
+    public function setLabel(string $label): void;
 }

--- a/src/Contracts/Entities/InstitutionTagInterface.php
+++ b/src/Contracts/Entities/InstitutionTagInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface InstitutionTagInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/MasterToebInterface.php
+++ b/src/Contracts/Entities/MasterToebInterface.php
@@ -2,7 +2,346 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use DateTime;
+use DateTimeInterface;
+
 interface MasterToebInterface extends UuidEntityInterface
 {
+    /**
+     * @return mixed
+     */
+    public function getGatewayGroup();
 
+    /**
+     * @param mixed $gatewayGroup
+     *
+     * @return MasterToebInterface
+     */
+    public function setGatewayGroup($gatewayGroup);
+
+    /**
+     * @return mixed
+     */
+    public function getOrgaName();
+
+    /**
+     * @param mixed $orgaName
+     *
+     * @return MasterToebInterface
+     */
+    public function setOrgaName($orgaName);
+
+    /**
+     * @return OrgaInterface
+     */
+    public function getOrga();
+
+    /**
+     * alias for @link MasterToebInterface::getOrga()
+     * @return OrgaInterface
+     */
+    public function getOrganisation();
+
+    /**
+     * @param mixed $orga
+     *
+     * @return MasterToebInterface
+     */
+    public function setOrga($orga);
+
+    /**
+     * alias for @link MasterToebInterface::setOrga()
+     * @param mixed $orga
+     *
+     * @return MasterToebInterface
+     */
+    public function setOrganisation($orga);
+
+    /**
+     * gets the Organisation id
+     * @return string|null
+     */
+    public function getOId();
+
+    /**
+     * @return mixed
+     */
+    public function getDepartment();
+
+    /**
+     * @param mixed $department
+     *
+     * @return MasterToebInterface
+     */
+    public function setDepartment($department);
+
+    /**
+     * gets the Department id
+     * @return string|null
+     */
+    public function getDId();
+
+    /**
+     * @return mixed
+     */
+    public function getDepartmentName();
+
+    /**
+     * @param mixed $departmentName
+     *
+     * @return MasterToebInterface
+     */
+    public function setDepartmentName($departmentName);
+
+    /**
+     * @return mixed
+     */
+    public function getSign();
+
+    /**
+     * @param mixed $sign
+     *
+     * @return MasterToebInterface
+     */
+    public function setSign($sign);
+
+    /**
+     * @return mixed *
+     */
+    public function getEmail();
+
+    /**
+     * @param mixed $email
+     *
+     * @return MasterToebInterface
+     */
+    public function setEmail($email);
+
+    /**
+     * @return mixed
+     */
+    public function getCcEmail();
+
+    /**
+     * @param mixed $ccEmail
+     *
+     * @return MasterToebInterface
+     */
+    public function setCcEmail($ccEmail);
+
+    /**
+     * @return mixed
+     */
+    public function getContactPerson();
+
+    /**
+     * @param string $contactPerson
+     *
+     * @return MasterToebInterface
+     */
+    public function setContactPerson($contactPerson);
+
+    /**
+     * @return mixed
+     */
+    public function getMemo();
+
+    /**
+     * @param mixed $memo
+     *
+     * @return MasterToebInterface
+     */
+    public function setMemo($memo);
+
+    /**
+     * @return int
+     */
+    public function getDistrictHHMitte();
+
+    /**
+     * @param int $districtHHMitte
+     *
+     * @return MasterToebInterface
+     */
+    public function setDistrictHHMitte($districtHHMitte);
+
+    /**
+     * @return mixed
+     */
+    public function getDistrictEimsbuettel();
+
+    /**
+     * @param int $districtEimsbuettel
+     *
+     * @return MasterToebInterface
+     */
+    public function setDistrictEimsbuettel($districtEimsbuettel);
+
+    /**
+     * @return int
+     */
+    public function getDistrictAltona();
+
+    /**
+     * @param int $districtAltona
+     *
+     * @return MasterToebInterface
+     */
+    public function setDistrictAltona($districtAltona);
+
+    /**
+     * @return int
+     */
+    public function getDistrictHHNord();
+
+    /**
+     * @param int $districtHHNord
+     *
+     * @return MasterToebInterface
+     */
+    public function setDistrictHHNord($districtHHNord);
+
+    /**
+     * @return int
+     */
+    public function getDistrictWandsbek();
+
+    /**
+     * @param int $districtWandsbek
+     *
+     * @return MasterToebInterface
+     */
+    public function setDistrictWandsbek($districtWandsbek);
+
+    /**
+     * @return int
+     */
+    public function getDistrictBergedorf();
+
+    /**
+     * @param int $districtBergedorf
+     *
+     * @return MasterToebInterface
+     */
+    public function setDistrictBergedorf($districtBergedorf);
+
+    /**
+     * @return int
+     */
+    public function getDistrictHarburg();
+
+    /**
+     * @param int $districtHarburg
+     *
+     * @return MasterToebInterface
+     */
+    public function setDistrictHarburg($districtHarburg);
+
+    /**
+     * @return int
+     */
+    public function getDistrictBsu();
+
+    /**
+     * @param int $districtBsu
+     *
+     * @return MasterToebInterface
+     */
+    public function setDistrictBsu($districtBsu);
+
+    /**
+     * @return bool
+     */
+    public function getDocumentRoughAgreement();
+
+    /**
+     * @param bool $documentRoughAgreement
+     *
+     * @return MasterToebInterface
+     */
+    public function setDocumentRoughAgreement($documentRoughAgreement);
+
+    /**
+     * @return bool
+     */
+    public function getDocumentAgreement();
+
+    /**
+     * @param bool $documentAgreement
+     *
+     * @return MasterToebInterface
+     */
+    public function setDocumentAgreement($documentAgreement);
+
+    /**
+     * @return bool
+     */
+    public function getDocumentNotice();
+
+    /**
+     * @param bool $documentNotice
+     *
+     * @return MasterToebInterface
+     */
+    public function setDocumentNotice($documentNotice);
+
+    /**
+     * @return bool
+     */
+    public function getDocumentAssessment();
+
+    /**
+     * @param bool $documentAssessment
+     *
+     * @return MasterToebInterface
+     */
+    public function setDocumentAssessment($documentAssessment);
+
+    /**
+     * @return bool
+     */
+    public function getRegistered();
+
+    /**
+     * @param int $registered
+     *
+     * @return MasterToebInterface
+     */
+    public function setRegistered($registered);
+
+    /**
+     * @return string
+     */
+    public function getComment();
+
+    /**
+     * @param string $comment
+     *
+     * @return MasterToebInterface
+     */
+    public function setComment($comment);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedDate();
+
+    /**
+     * @param DateTime $createdDate
+     *
+     * @return MasterToebInterface
+     */
+    public function setCreatedDate(DateTimeInterface $createdDate);
+
+    /**
+     * @return DateTime
+     */
+    public function getModifiedDate();
+
+    /**
+     * @param DateTime $modifiedDate
+     *
+     * @return MasterToebInterface
+     */
+    public function setModifiedDate(DateTimeInterface $modifiedDate);
 }

--- a/src/Contracts/Entities/MasterToebInterface.php
+++ b/src/Contracts/Entities/MasterToebInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface MasterToebInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/OrgaInterface.php
+++ b/src/Contracts/Entities/OrgaInterface.php
@@ -128,7 +128,6 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
      * @param string $subdomain
      *
      * @return OrgaTypeInterface[]
-     * fixme adjust this method in Core OrgaTypeInterface[]
      */
     public function getOrgaTypes($subdomain, bool $acceptedOnly): array;
 
@@ -145,13 +144,11 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
 
     /**
      * @return Collection<int,AddressInterface>
-     * fixme adjust this method in Core AddressCollection
      */
     public function getAddresses(): Collection;
 
     /**
      * @param AddressInterface[] $addresses
-     * fixme adjust this method in Core AddressInterface[]
      */
     public function setAddresses(array $addresses): self;
 
@@ -159,12 +156,10 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
      * Returns the address of the orga. It should only be one.
      *
      * @return AddressInterface|false note that the return types of first() are the object or false
-     * fixme adjust this method in Core AddressInterface
      */
     public function getAddress();
 
     public function addAddress(AddressInterface $address): self;
-//    fixme adjust this method in Core AddressInterface
 
     /**
      * Get Street from associated (first) Address.
@@ -273,13 +268,11 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
 
     /**
      * Add user to this Organisation, if not already exists in the collection.
-     * fixme adjust this method in Core UserInterface
      */
     public function addUser(UserInterface $user): self;
 
     /**
      * Remove user from this Organisation.
-     * fixme adjust this method in Core UserInterface
      */
     public function removeUser(UserInterface $user): self;
 
@@ -287,13 +280,11 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
 
     /**
      * @param array<int,DepartmentInterface> $departments
-     * fixme adjust this method in Core DepartmentInterface
      */
     public function setDepartments($departments): self;
 
     /**
      * Add department to this Organisation.
-     * fixme adjust this method in Core DepartmentInterface
      */
     public function addDepartment(DepartmentInterface $department): self;
 
@@ -325,12 +316,10 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
 
     /**
      * @param AddressBookEntryInterface[] $addressBookEntries
-     * fixme adjust this method in Core AddressBookEntryInterface
      */
     public function setAddressBookEntries(array $addressBookEntries): self;
 
     /**
-     * fixme adjust this method in Core AddressBookEntryInterface
      * Add a single AddressBookEntry, if not already present in $this->addressBook.
      *
      * @return bool "true" if the given AddressBookEntry was successfully added to this organisation
@@ -368,14 +357,10 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
     public function getStatusInCustomers(): Collection;
 
     /**
-     * fixme adjust this method in Core OrgaStatusInCustomerInterface
      * @param Collection<int, OrgaStatusInCustomerInterface> $statusInCustomers
      */
     public function setStatusInCustomers(Collection $statusInCustomers): self;
 
-    /**
-    * fixme adjust this method in Core OrgaStatusInCustomerInterface
-    */
     public function addStatusInCustomer(OrgaStatusInCustomerInterface $orgaStatusInCustomer): self;
 
     public function addCustomer(CustomerInterface $customer): bool;
@@ -416,11 +401,7 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
     public function getMasterUser(string $subdomain): ?UserInterface;
 
     public function getMasterToeb(): ?MasterToebInterface;
-    // fixme MasterToebInterface needs to be implemented by MasterToeb in core
 
-    /**
-     * fixme adjust this method in Core MasterToebInterface
-     */
     public function setMasterToeb(?MasterToebInterface $masterToeb): self;
 
     public function hasType(string $orgaType, string $currentSubdomain): bool;
@@ -428,32 +409,18 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
     public function isDefaultCitizenOrganisation(): bool;
 
     public function getBranding(): ?BrandingInterface;
-    // fixme BrandingInterface needs to be implemented by Branding in core
 
-    /**
-     * fixme adjust this method in Core BrandingInterface
-     */
     public function setBranding(?BrandingInterface $branding): self;
 
     /**
-     * fixme the IstitutionTag in core needs to implement InstitutionTagInterface
      * @return Collection<int, InstitutionTagInterface>
      */
     public function getAssignedTags(): Collection;
 
-    /**
-     * fixme adjust this method in Core InstitutionTagInterface
-     */
     public function addAssignedTag(InstitutionTagInterface $tag): void;
 
-    /**
-     * fixme adjust this method in Core InstitutionTagInterface
-     */
     public function removeAssignedTag(InstitutionTagInterface $tag): void;
 
-    /**
-     * fixme adjust this method in Core InstitutionTagInterface
-     */
     public function addOwnInstitutionTag(InstitutionTagInterface $tag): void;
 
     /**
@@ -461,8 +428,5 @@ interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, Slugge
     */
     public function getOwnInstitutionTags(): Collection;
 
-    /**
-     * fixme adjust this method in Core InstitutionTagInterface
-     */
     public function removeOwnInstitutionTag(InstitutionTagInterface $tag): void;
 }

--- a/src/Contracts/Entities/OrgaInterface.php
+++ b/src/Contracts/Entities/OrgaInterface.php
@@ -4,7 +4,465 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface OrgaInterface
-{
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Tightenco\Collect\Support\Collection as TightencoCollection;
 
+/**
+ * additional methods inherited from SluggedEntity are not part of this interface
+ */
+interface OrgaInterface extends UuidEntityInterface, CoreEntityInterface, SluggedEntityInterface
+{
+    /**
+     * Key for default statement submission type with coordinator.
+     */
+    public const STATEMENT_SUBMISSION_TYPE_DEFAULT = 'standard';
+
+    /**
+     * Key for short statement submission type without coordinator.
+     */
+    public const STATEMENT_SUBMISSION_TYPE_SHORT = 'short';
+
+    public function setId(string $id): self;
+
+    public function setName(?string $name): self;
+
+    public function getName(): ?string;
+
+    /**
+     * Alias for getName().
+     */
+    public function getNameLegal(): ?string;
+
+    public function getGatewayName(): ?string;
+
+    public function setGatewayName(?string $gatewayName): self;
+
+    public function setCode(?string $code): self;
+
+    public function getCode(): ?string;
+
+    /**
+     * @param DateTime|DateTimeImmutable $createdDate
+     */
+    public function setCreatedDate(DateTimeInterface $createdDate): self;
+
+    /**
+     * @return DateTime|DateTimeImmutable
+     */
+    public function getCreatedDate(): DateTimeInterface;
+
+    /**
+     * @param DateTime|DateTimeImmutable $modifiedDate
+     */
+    public function setModifiedDate(DateTimeInterface $modifiedDate): self;
+
+    /**
+     * @return DateTime|DateTimeImmutable
+     */
+    public function getModifiedDate(): DateTimeInterface;
+
+    public function getCcEmail2(): ?string;
+
+    public function setCcEmail2(?string $ccEmail2): self;
+
+    public function getEmailReviewerAdmin(): ?string;
+
+    public function setEmailReviewerAdmin(?string $emailReviewerAdmin): self;
+
+    public function setDeleted(bool $deleted): self;
+
+    public function getDeleted(): bool;
+
+    public function isDeleted(): bool;
+
+    public function setShowname(bool $showname): self;
+
+    public function getShowname(): bool;
+
+    public function isShowname(): bool;
+
+    public function setShowlist(bool $showlist): self;
+
+    public function getShowlist(): bool;
+
+    public function isShowlist(): bool;
+
+    public function setGwId(?string $gwId): self;
+
+    public function getGwId(): ?string;
+
+    public function setCompetence(?string $competence): self;
+
+    public function getCompetence(): ?string;
+
+    public function setEmail2(?string $email2): self;
+
+    public function getEmail2(): ?string;
+
+    public function getParticipationEmail(): ?string;
+
+    public function setParticipationEmail(string $emailAddress): self;
+
+    public function getContactPerson(): ?string;
+
+    public function setContactPerson(?string $contactPerson): self;
+
+    public function setPaperCopy(int $paperCopy): self;
+
+    public function getPaperCopy(): ?int;
+
+    public function setPaperCopySpec(?string $paperCopySpec): self;
+
+    public function getPaperCopySpec(): ?string;
+
+    /**
+     * Get OrgaType.
+     *
+     * Needs to be callable without subdomain as getters are dynamically built
+     * in convertToLegacy functions where no parameter is given
+     *
+     * @param string $subdomain
+     *
+     * @return OrgaTypeInterface[]
+     * fixme adjust this method in Core OrgaTypeInterface[]
+     */
+    public function getOrgaTypes($subdomain, bool $acceptedOnly): array;
+
+    /**
+     * Shortcut get OrgaType name.
+     * Needs to be callable without subdomain as getters are dynamically built
+     * in convertToLegacy functions where no parameter is given.
+     *
+     * @param string $subdomain
+     *
+     * @return string[]
+     */
+    public function getTypes($subdomain, bool $acceptedOnly): array;
+
+    /**
+     * @return Collection<int,AddressInterface>
+     * fixme adjust this method in Core AddressCollection
+     */
+    public function getAddresses(): Collection;
+
+    /**
+     * @param AddressInterface[] $addresses
+     * fixme adjust this method in Core AddressInterface[]
+     */
+    public function setAddresses(array $addresses): self;
+
+    /**
+     * Returns the address of the orga. It should only be one.
+     *
+     * @return AddressInterface|false note that the return types of first() are the object or false
+     * fixme adjust this method in Core AddressInterface
+     */
+    public function getAddress();
+
+    public function addAddress(AddressInterface $address): self;
+//    fixme adjust this method in Core AddressInterface
+
+    /**
+     * Get Street from associated (first) Address.
+     *
+     * @return string can be street (string) or empty string
+     */
+    public function getStreet(): string;
+
+    public function setStreet($street): self;
+
+    /**
+     * Get Street from associated (first) Address.
+     */
+    public function getHouseNumber(): string;
+
+    public function setHouseNumber($houseNumber): self;
+
+    /**
+     * Get State from associated (first) Address.
+     */
+    public function getState(): string;
+
+    public function setState($state): self;
+
+    /**
+     * Get Fax from associated (first) Address.
+     */
+    public function getFax();
+
+    /**
+     * @param string $fax
+     */
+    public function setFax($fax): self;
+
+    /**
+     * Get Postalcode from associated (first) Address.
+     */
+    public function getPostalcode(): string;
+
+    /**
+     * @param string $postalcode
+     */
+    public function setPostalcode($postalcode): self;
+
+    /**
+     * Get City from associated (first) Address.
+     */
+    public function getCity();
+
+    /**
+     * @param string $city
+     */
+    public function setCity($city): self;
+
+    /**
+     * Get Phone from associated (first) Address.
+     */
+    public function getPhone(): string;
+
+    /**
+     * @param string $phone
+     */
+    public function setPhone($phone): self;
+
+    public function getDataProtection(): string;
+
+    public function setDataProtection(string $dataProtection): self;
+
+    public function getImprint(): string;
+
+    public function setImprint(string $imprint): self;
+
+    public function addAdministratableProcedure(ProcedureInterface $procedure): bool;
+
+    /**
+     * @return Collection<int, ProcedureInterface>
+     */
+    public function getAdministratableProcedures(): Collection;
+
+    /**
+     * @return array
+     */
+    public function getNotifications();
+
+    /**
+     * @param array $notifications
+     */
+    public function setNotifications($notifications): self;
+
+    public function addNotification($notification): self;
+
+    /**
+     * @return ArrayCollection|TightencoCollection
+     */
+    public function getAllUsers();
+
+    /**
+     * Returns all users of this organisation, which are not deleted === true.
+     */
+    public function getUsers(): TightencoCollection;
+
+    /**
+     * @param array<int,UserInterface> $users
+     */
+    public function setUsers($users): self;
+
+    /**
+     * Add user to this Organisation, if not already exists in the collection.
+     * fixme adjust this method in Core UserInterface
+     */
+    public function addUser(UserInterface $user): self;
+
+    /**
+     * Remove user from this Organisation.
+     * fixme adjust this method in Core UserInterface
+     */
+    public function removeUser(UserInterface $user): self;
+
+    public function getDepartments(): TightencoCollection;
+
+    /**
+     * @param array<int,DepartmentInterface> $departments
+     * fixme adjust this method in Core DepartmentInterface
+     */
+    public function setDepartments($departments): self;
+
+    /**
+     * Add department to this Organisation.
+     * fixme adjust this method in Core DepartmentInterface
+     */
+    public function addDepartment(DepartmentInterface $department): self;
+
+    /**
+     * @return ArrayCollection|Collection
+     */
+    public function getProcedures();
+
+    /**
+     * @param ArrayCollection<int,ProcedureInterface>|Collection<int,ProcedureInterface> $procedures
+     */
+    public function setProcedures($procedures): self;
+
+    public function getSubmissionType(): string;
+
+    public function setSubmissionType(string $submissionType): self;
+
+    /**
+     * Returns all user (of all departments) of this organisation.
+     *
+     * @return TightencoCollection[User]
+     */
+    public function getAllUsersOfDepartments();
+
+    /**
+     * @return ArrayCollection|Collection
+     */
+    public function getAddressBookEntries();
+
+    /**
+     * @param AddressBookEntryInterface[] $addressBookEntries
+     * fixme adjust this method in Core AddressBookEntryInterface
+     */
+    public function setAddressBookEntries(array $addressBookEntries): self;
+
+    /**
+     * fixme adjust this method in Core AddressBookEntryInterface
+     * Add a single AddressBookEntry, if not already present in $this->addressBook.
+     *
+     * @return bool "true" if the given AddressBookEntry was successfully added to this organisation
+     *              and this organisation was successfully added to the given AddressBookEntry, otherwise "false"
+     */
+    public function addAddressBookEntry(AddressBookEntryInterface $addressBookEntry): bool;
+
+    /**
+     * Removes a AddressBookEntry from this Organisation and also removes the other side of the relation.
+     */
+    public function removeAddressBookEntry(AddressBookEntryInterface $addressBookEntry): self;
+
+    public function getLogo(): ?FileInterface;
+
+    public function setLogo(?FileInterface $logo): self;
+
+    /**
+     * @return Collection<int, CustomerInterface>
+     */
+    public function getCustomers();
+
+    /**
+     * @param string $status for a list of Values check
+     * @link OrgaStatusInCustomerInterface
+     */
+    public function addCustomerAndOrgaType(
+        CustomerInterface $customer,
+        OrgaTypeInterface $orgaType,
+        string $status
+    ): self;
+
+    /**
+     * @return Collection<int, OrgaStatusInCustomerInterface>
+     */
+    public function getStatusInCustomers(): Collection;
+
+    /**
+     * fixme adjust this method in Core OrgaStatusInCustomerInterface
+     * @param Collection<int, OrgaStatusInCustomerInterface> $statusInCustomers
+     */
+    public function setStatusInCustomers(Collection $statusInCustomers): self;
+
+    /**
+    * fixme adjust this method in Core OrgaStatusInCustomerInterface
+    */
+    public function addStatusInCustomer(OrgaStatusInCustomerInterface $orgaStatusInCustomer): self;
+
+    public function addCustomer(CustomerInterface $customer): bool;
+
+    /**
+     * @param CustomerInterface[] $customers
+     */
+    public function addCustomers(array $customers): self;
+
+    /**
+     * Removes the customer from the list. If this is no Public Affairs Agency throws an InvalidArgumentException.
+     * If it doesn't exists then does nothing.
+     */
+    public function removeCustomer(CustomerInterface $customer): self;
+
+    public function __toString(): string;
+
+    /**
+     * Is current Orga registered in given customer/subdomain?
+     */
+    public function isRegisteredInSubdomain($subdomain): bool;
+
+    /**
+     * @return CustomerInterface|null
+     */
+    public function getMainCustomer();
+
+    /**
+     * Given an orga type name and a status ('pending', 'accepted', 'rejected') returns
+     * the subdomains where the orga meets the two conditions.
+     *
+     * @see OrgaTypeInterface::PLANNING_AGENCY, OrgaTypeInterface::MUNICIPALITY, etc.
+     *
+     * @return CustomerInterface[]
+     */
+    public function getCustomersByActivationStatus(string $orgaTypeName, string $status): array;
+
+    public function getMasterUser(string $subdomain): ?UserInterface;
+
+    public function getMasterToeb(): ?MasterToebInterface;
+    // fixme MasterToebInterface needs to be implemented by MasterToeb in core
+
+    /**
+     * fixme adjust this method in Core MasterToebInterface
+     */
+    public function setMasterToeb(?MasterToebInterface $masterToeb): self;
+
+    public function hasType(string $orgaType, string $currentSubdomain): bool;
+
+    public function isDefaultCitizenOrganisation(): bool;
+
+    public function getBranding(): ?BrandingInterface;
+    // fixme BrandingInterface needs to be implemented by Branding in core
+
+    /**
+     * fixme adjust this method in Core BrandingInterface
+     */
+    public function setBranding(?BrandingInterface $branding): self;
+
+    /**
+     * fixme the IstitutionTag in core needs to implement InstitutionTagInterface
+     * @return Collection<int, InstitutionTagInterface>
+     */
+    public function getAssignedTags(): Collection;
+
+    /**
+     * fixme adjust this method in Core InstitutionTagInterface
+     */
+    public function addAssignedTag(InstitutionTagInterface $tag): void;
+
+    /**
+     * fixme adjust this method in Core InstitutionTagInterface
+     */
+    public function removeAssignedTag(InstitutionTagInterface $tag): void;
+
+    /**
+     * fixme adjust this method in Core InstitutionTagInterface
+     */
+    public function addOwnInstitutionTag(InstitutionTagInterface $tag): void;
+
+    /**
+    * @return Collection<int, InstitutionTagInterface>
+    */
+    public function getOwnInstitutionTags(): Collection;
+
+    /**
+     * fixme adjust this method in Core InstitutionTagInterface
+     */
+    public function removeOwnInstitutionTag(InstitutionTagInterface $tag): void;
 }

--- a/src/Contracts/Entities/OrgaStatusInCustomerInterface.php
+++ b/src/Contracts/Entities/OrgaStatusInCustomerInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface OrgaStatusInCustomerInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/OrgaTypeInterface.php
+++ b/src/Contracts/Entities/OrgaTypeInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface OrgaTypeInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/SlugInterface.php
+++ b/src/Contracts/Entities/SlugInterface.php
@@ -4,5 +4,9 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 interface SlugInterface extends UuidEntityInterface
 {
+    public function setId(string $id);
 
+    public function getName(): string;
+
+    public function setName(string $name);
 }

--- a/src/Contracts/Entities/SlugInterface.php
+++ b/src/Contracts/Entities/SlugInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface SlugInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/SluggedEntityInterface.php
+++ b/src/Contracts/Entities/SluggedEntityInterface.php
@@ -2,7 +2,35 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use Doctrine\Common\Collections\Collection;
+use Exception;
+
 interface SluggedEntityInterface extends UuidEntityInterface
 {
+    public function getSlugs(): Collection;
 
+    public function setSlugs(Collection $slugs);
+
+    /**
+     * Given a Slug object adds it to the Entity, updating its slugs history and sets it as current Slug.
+     *
+     * @return SluggedEntityInterface
+     */
+    public function addSlug(SlugInterface $slug);
+
+    public function getCurrentSlug(): SlugInterface;
+
+    /**
+     * @throws Exception
+     */
+    public function setCurrentSlug(SlugInterface $currentSlug);
+
+    /**
+     * Returns true if the Orga already had the received slug, false otherwise.
+     */
+    public function hasSlugString(SlugInterface $slug): bool;
+
+    public function isSlugCurrent(string $slug): bool;
+
+    public function setInitialSlug();
 }

--- a/src/Contracts/Entities/SluggedEntityInterface.php
+++ b/src/Contracts/Entities/SluggedEntityInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface SluggedEntityInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface UserInterface extends UuidEntityInterface
+{
+
+}

--- a/src/Logic/ApiRequest/Transformer/BaseTransformerInterface.php
+++ b/src/Logic/ApiRequest/Transformer/BaseTransformerInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DemosEurope\DemosplanAddon\Logic\ApiRequest\Transformer;
+
+use DateTime;
+use DemosEurope\DemosplanAddon\Contracts\ApiRequest\ApiResourceServiceInterface;
+use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
+
+interface BaseTransformerInterface
+{
+    public function getClass(): string;
+
+    /**
+     * @deprecated use {@link ResourceTypeInterface::getName()} where possible, because it should
+     *             be the actual source for this information and not the transformer
+     */
+    public function getType(): string;
+
+    public function getPermissions(): PermissionsInterface;
+
+    /**
+     * Please don't use `@required` for DI. It should only be used in base classes like this one.
+     *
+     * @required
+     */
+    public function setPermissions(PermissionsInterface $permissions): void;
+
+    /**
+     * @param DateTime $date
+     */
+    public function formatDate($date): string;
+
+    /**
+     * Please don't use `@required` for DI. It should only be used in base classes like this one.
+     *
+     * @required
+     */
+    public function setResourceService(ApiResourceServiceInterface $resourceService): void;
+
+    public function getGlobalConfig(): GlobalConfigInterface;
+
+    /**
+     * Please don't use `@required` for DI. It should only be used in base classes like this one.
+     *
+     * @required
+     */
+    public function setGlobalConfig(GlobalConfigInterface $globalConfig): void;
+
+}


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32212

Description:
add methods to interfaces / add new necessary interfaces...

the CoreEntityInterface now requires the method getEntityContentChangeIdentifier() which is not implemented by all entities inside addons. This has to be changed. - done in https://github.com/demos-europe/demosplan-addon-demospipes/pull/70


I did not finish the whole thing, but everything should be in a valid state at this point.

### Linked PRs (optional)
 - this PR is dependent on https://github.com/demos-europe/demosplan-core/pull/1254 and needs to be merged together.
 - this PR is dependent on https://github.com/demos-europe/demosplan-addon-demospipes/pull/70
###

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly