### PR TITLE
feat: Extend PHP version allowance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "composer-plugin-api": "^2.0",
-        "php": "8.1.*",
+        "php": ">=8.1.*,<9.*",
         "symfony/yaml": "5.*.*",
         "symfony/security-core": "5.*.*",
         "tightenco/collect": "~8.83.0",


### PR DESCRIPTION
Since PHP 8.2 is creeping into our stack we need to allow for it in our base packages.