### PR TITLE
feat (T32606): remove static context for createChild

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "composer-plugin-api": "^2.0",
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "symfony/yaml": "5.*.*",
         "symfony/security-core": "5.*.*",
         "tightenco/collect": "~8.83.0",


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32606

Description:
remove static context for createChild and findImplementationOfInterface in AddonResourceType and use the container instead of get_declared_classes, because get_declared_classes doesn't return all relevant classes.