### PR TITLE
F t32212 add addon interfaces add necessary interfaces

### DIFF
--- a/src/Contracts/ApiRequest/ApiResourceServiceInterface.php
+++ b/src/Contracts/ApiRequest/ApiResourceServiceInterface.php
@@ -9,7 +9,7 @@ use DemosEurope\DemosplanAddon\Contracts\ValueObject\ValueObjectInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\Transformer\BaseTransformerInterface;
 use Exception;
 use League\Fractal\Manager;
-use Doctrine\Common\Collections\Collection;
+use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use Symfony\Component\Security\Core\User\UserInterface;
 

--- a/src/Contracts/ApiRequest/ApiResourceServiceInterface.php
+++ b/src/Contracts/ApiRequest/ApiResourceServiceInterface.php
@@ -9,7 +9,7 @@ use DemosEurope\DemosplanAddon\Contracts\ValueObject\ValueObjectInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\Transformer\BaseTransformerInterface;
 use Exception;
 use League\Fractal\Manager;
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\Collection;
 use League\Fractal\Resource\Item;
 use Symfony\Component\Security\Core\User\UserInterface;
 

--- a/src/Contracts/Entities/AddressBookEntryInterface.php
+++ b/src/Contracts/Entities/AddressBookEntryInterface.php
@@ -6,7 +6,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 
-interface AddressBookEntryInterface extends UuidEntityInterface
+interface AddressBookEntryInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function getName(): ?string;
 

--- a/src/Contracts/Entities/AddressInterface.php
+++ b/src/Contracts/Entities/AddressInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use DateTime;
 use DateTimeInterface;
 
-interface AddressInterface extends UuidEntityInterface
+interface AddressInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function setCode(?string $code): self;
 

--- a/src/Contracts/Entities/BoilerplateCategoryInterface.php
+++ b/src/Contracts/Entities/BoilerplateCategoryInterface.php
@@ -5,12 +5,16 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 
-interface BoilerplateCategoryInterface extends UuidEntityInterface
+interface BoilerplateCategoryInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const TITLE_NEWS_NOTES = 'news.notes';
     public const TITLE_EMAIL = 'email';
     public const TITLE_CONSIDERATION = 'consideration';
 
+    /**
+     * @return string
+     */
+    public function getPId();
 
     /**
      * @return ProcedureInterface

--- a/src/Contracts/Entities/BoilerplateCategoryInterface.php
+++ b/src/Contracts/Entities/BoilerplateCategoryInterface.php
@@ -3,7 +3,7 @@
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 interface BoilerplateCategoryInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/BoilerplateGroupInterface.php
+++ b/src/Contracts/Entities/BoilerplateGroupInterface.php
@@ -3,7 +3,7 @@
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 interface BoilerplateGroupInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/BoilerplateGroupInterface.php
+++ b/src/Contracts/Entities/BoilerplateGroupInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 
-interface BoilerplateGroupInterface extends UuidEntityInterface
+interface BoilerplateGroupInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @param string $id

--- a/src/Contracts/Entities/BoilerplateInterface.php
+++ b/src/Contracts/Entities/BoilerplateInterface.php
@@ -3,7 +3,7 @@
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 interface BoilerplateInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/BoilerplateInterface.php
+++ b/src/Contracts/Entities/BoilerplateInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 
-interface BoilerplateInterface extends UuidEntityInterface
+interface BoilerplateInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @param string $ident

--- a/src/Contracts/Entities/BrandingInterface.php
+++ b/src/Contracts/Entities/BrandingInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface BrandingInterface extends UuidEntityInterface
+interface BrandingInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function getCssvars(): ?string;
 

--- a/src/Contracts/Entities/CountyInterface.php
+++ b/src/Contracts/Entities/CountyInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
-interface CountyInterface extends UuidEntityInterface
+interface CountyInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @return Collection<int, CustomerCountyInterface>

--- a/src/Contracts/Entities/CountyInterface.php
+++ b/src/Contracts/Entities/CountyInterface.php
@@ -2,8 +2,8 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\ArrayCollection;
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 
 interface CountyInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/CustomerCountyInterface.php
+++ b/src/Contracts/Entities/CustomerCountyInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface CustomerCountyInterface extends UuidEntityInterface
+interface CustomerCountyInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function setId(string $id): self;
 

--- a/src/Contracts/Entities/CustomerInterface.php
+++ b/src/Contracts/Entities/CustomerInterface.php
@@ -6,7 +6,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use Doctrine\Common\Collections\Collection;
 
-interface CustomerInterface extends UuidEntityInterface
+interface CustomerInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function setId(string $id);
 

--- a/src/Contracts/Entities/CustomerInterface.php
+++ b/src/Contracts/Entities/CustomerInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\Collection;
 
 interface CustomerInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/DraftStatementFileInterface.php
+++ b/src/Contracts/Entities/DraftStatementFileInterface.php
@@ -4,6 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
+
 interface DraftStatementFileInterface extends UuidEntityInterface
 {
     public function getDraftStatement(): ?DraftStatementInterface;

--- a/src/Contracts/Entities/DraftStatementFileInterface.php
+++ b/src/Contracts/Entities/DraftStatementFileInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface DraftStatementFileInterface extends UuidEntityInterface
+{
+    public function getDraftStatement(): ?DraftStatementInterface;
+
+    /**
+     * Set to null to activate orphan removal.
+     */
+    public function setDraftStatement(?DraftStatementInterface $draftStatement): self;
+
+    public function getCreateDate(): DateTime;
+
+    public function getFile(): FileInterface;
+
+    public function setFile(FileInterface $file): self;
+
+    public function getFileString(): ?string;
+
+}

--- a/src/Contracts/Entities/DraftStatementFileInterface.php
+++ b/src/Contracts/Entities/DraftStatementFileInterface.php
@@ -14,7 +14,7 @@ interface DraftStatementFileInterface extends UuidEntityInterface
      */
     public function setDraftStatement(?DraftStatementInterface $draftStatement): self;
 
-    public function getCreateDate(): DateTime;
+    public function getCreateDate(): \DateTimeInterface;
 
     public function getFile(): FileInterface;
 

--- a/src/Contracts/Entities/DraftStatementFileInterface.php
+++ b/src/Contracts/Entities/DraftStatementFileInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use DateTime;
+use DateTimeInterface;
 
 
 interface DraftStatementFileInterface extends UuidEntityInterface
@@ -14,7 +14,7 @@ interface DraftStatementFileInterface extends UuidEntityInterface
      */
     public function setDraftStatement(?DraftStatementInterface $draftStatement): self;
 
-    public function getCreateDate(): \DateTimeInterface;
+    public function getCreateDate(): DateTimeInterface;
 
     public function getFile(): FileInterface;
 

--- a/src/Contracts/Entities/DraftStatementInterface.php
+++ b/src/Contracts/Entities/DraftStatementInterface.php
@@ -4,17 +4,11 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface DraftStatementInterface extends UuidEntityInterface
+interface DraftStatementInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const INTERNAL = 'internal';
 
     public const EXTERNAL = 'external';
-
-
-    /**
-     * @deprecated use {@link DraftStatementInterface::getId()} instead
-     */
-    public function getIdent(): ?string;
 
     /**
      * Set procedure.

--- a/src/Contracts/Entities/DraftStatementInterface.php
+++ b/src/Contracts/Entities/DraftStatementInterface.php
@@ -1,0 +1,789 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface DraftStatementInterface extends UuidEntityInterface
+{
+    public const INTERNAL = 'internal';
+
+    public const EXTERNAL = 'external';
+
+
+    /**
+     * @deprecated use {@link DraftStatementInterface::getId()} instead
+     */
+    public function getIdent(): ?string;
+
+    /**
+     * Set procedure.
+     *
+     * @param ProcedureInterface $procedure
+     *
+     * @return DraftStatementInterface
+     */
+    public function setProcedure($procedure);
+
+    /**
+     * Get procedure.
+     *
+     * @return ProcedureInterface
+     */
+    public function getProcedure();
+
+    /**
+     * Get pId.
+     *
+     * @return string
+     */
+    public function getPId();
+
+    /**
+     * Get ProcedureId.
+     *
+     * @return string
+     */
+    public function getProcedureId();
+
+    /**
+     * Set number.
+     *
+     * @param int $number
+     *
+     * @return DraftStatementInterface
+     */
+    public function setNumber($number);
+
+    /**
+     * Get number.
+     *
+     * @return int
+     */
+    public function getNumber();
+
+    /**
+     * Set title.
+     *
+     * @param string $title
+     *
+     * @return DraftStatementInterface
+     */
+    public function setTitle($title);
+
+    /**
+     * @return string
+     */
+    public function getTitle();
+
+    /**
+     * Get text.
+     *
+     * @return string
+     */
+    public function getText();
+
+    /**
+     * @param string $text
+     */
+    public function setText($text);
+
+    /**
+     * @return ParagraphVersionInterface|null
+     */
+    public function getParagraph();
+
+    /**
+     * @param ParagraphVersionInterface|null $paragraph
+     */
+    public function setParagraph($paragraph);
+
+    /**
+     * Get paragraphId.
+     *
+     * @return string
+     */
+    public function getParagraphId();
+
+    /**
+     * @return SingleDocumentVersionInterface|null
+     */
+    public function getDocument();
+
+    /**
+     * @param SingleDocumentVersionInterface|null $documentVersion
+     */
+    public function setDocument($documentVersion);
+
+    /**
+     * Get documentId.
+     *
+     * @return string
+     */
+    public function getDocumentId();
+
+    /**
+     * Get elementId.
+     *
+     * @return string
+     */
+    public function getElementId();
+
+    /**
+     * Get elementTitle.
+     *
+     * @return string
+     */
+    public function getElementTitle();
+
+    /**
+     * @return ElementsInterface|null
+     */
+    public function getElement();
+
+    /**
+     * @param ElementsInterface|null $element
+     */
+    public function setElement($element);
+
+    /**
+     * Set polygon.
+     *
+     * @param string $polygon
+     *
+     * @return DraftStatementInterface
+     */
+    public function setPolygon($polygon);
+
+    /**
+     * Get polygon.
+     *
+     * @return string
+     */
+    public function getPolygon();
+
+    /**
+     * Set file.
+     *
+     * @param string $file
+     *
+     * @return DraftStatementInterface
+     */
+    public function setFile($file);
+
+    /**
+     * Get file.
+     *
+     * @return string
+     */
+    public function getFile();
+
+    /**
+     * Return FileStrings to keep method backwards compatible.
+     *
+     * @return array<int,string|null>
+     */
+    public function getFiles(): array;
+
+    public function addFile(DraftStatementFileInterface $draftStatementFile): self;
+
+    public function removeFile(DraftStatementFileInterface $draftStatementFile): self;
+
+    public function removeFileByFileId(string $fileId): self;
+
+    /**
+     * Set mapFile.
+     *
+     * @param string $mapFile
+     *
+     * @return DraftStatementInterface
+     */
+    public function setMapFile($mapFile);
+
+    /**
+     * Get mapFile.
+     *
+     * @return string
+     */
+    public function getMapFile();
+
+    /**
+     * Set oId.
+     *
+     * @param OrgaInterface $organisation
+     *
+     * @return DraftStatementInterface
+     */
+    public function setOrganisation($organisation);
+
+    public function getOrganisation(): OrgaInterface;
+
+    /**
+     * Get Organisation Id.
+     *
+     * @return string
+     */
+    public function getOId();
+
+    /**
+     * Get Organisation GatewayName.
+     *
+     * @return string
+     */
+    public function getOGatewayName();
+
+    /**
+     * Set oName.
+     *
+     * @param string $oName
+     *
+     * @return DraftStatementInterface
+     */
+    public function setOName($oName);
+
+    /**
+     * Get oName.
+     *
+     * @return string
+     */
+    public function getOName();
+
+    /**
+     * Set dName.
+     *
+     * @param string $dName
+     *
+     * @return DraftStatementInterface
+     */
+    public function setDName($dName);
+
+    /**
+     * Get dName.
+     *
+     * @return string
+     */
+    public function getDName();
+
+    /**
+     * @return mixed|DepartmentInterface
+     */
+    public function getDepartment();
+
+    /**
+     * @param DepartmentInterface $department
+     */
+    public function setDepartment($department);
+
+    public function getDId();
+
+    /**
+     * Set user.
+     *
+     * @param UserInterface $user
+     *
+     * @return DraftStatementInterface
+     */
+    public function setUser($user);
+
+    /**
+     * Get user.
+     *
+     * @return UserInterface
+     */
+    public function getUser();
+
+    /**
+     * @return string
+     */
+    public function getUId();
+
+    /**
+     * Set uName.
+     *
+     * @param string $uName
+     *
+     * @return DraftStatementInterface
+     */
+    public function setUName($uName);
+
+    /**
+     * Get uName.
+     *
+     * @return string
+     */
+    public function getUName();
+
+    /**
+     * Set uStreet.
+     *
+     * @param string $uStreet
+     *
+     * @return DraftStatementInterface
+     */
+    public function setUStreet($uStreet);
+
+    /**
+     * Get uStreet.
+     *
+     * @return string
+     */
+    public function getUStreet();
+
+    /**
+     * @return mixed
+     */
+    public function getCategories();
+
+    /**
+     * @param mixed $categories
+     */
+    public function setCategories($categories);
+
+    /**
+     * Reset Categories.
+     */
+    public function clearCategories();
+
+    /**
+     * Set uPostalCode.
+     *
+     * @param string $uPostalCode
+     *
+     * @return DraftStatementInterface
+     */
+    public function setUPostalCode($uPostalCode);
+
+    /**
+     * Get uPostalCode.
+     *
+     * @return string
+     */
+    public function getUPostalCode();
+
+    /**
+     * Set uCity.
+     *
+     * @param string $uCity
+     *
+     * @return DraftStatementInterface
+     */
+    public function setUCity($uCity);
+
+    /**
+     * Get uCity.
+     *
+     * @return string
+     */
+    public function getUCity();
+
+    /**
+     * Set uEmail.
+     *
+     * @param string $uEmail
+     *
+     * @return DraftStatementInterface
+     */
+    public function setUEmail($uEmail);
+
+    /**
+     * Get uEmail.
+     *
+     * @return string
+     */
+    public function getUEmail();
+
+    public function setUFeedback(bool $uFeedback): self;
+
+    public function getUFeedback(): bool;
+
+    /**
+     * Set feedback.
+     *
+     * @param string $feedback
+     *
+     * @return DraftStatementInterface
+     */
+    public function setFeedback($feedback);
+
+    /**
+     * Get feedback.
+     *
+     * @return string
+     */
+    public function getFeedback();
+
+    /**
+     * Set externId.
+     *
+     * @param string $externId
+     *
+     * @return DraftStatementInterface
+     */
+    public function setExternId($externId);
+
+    /**
+     * Get externId.
+     *
+     * @return string
+     */
+    public function getExternId();
+
+    /**
+     * Set rejectedReason.
+     *
+     * @param string $rejectedReason
+     *
+     * @return DraftStatementInterface
+     */
+    public function setRejectedReason($rejectedReason);
+
+    /**
+     * Get rejectedReason.
+     *
+     * @return string
+     */
+    public function getRejectedReason();
+
+    /**
+     * Set negativ.
+     *
+     * @param bool $negativ
+     *
+     * @return DraftStatementInterface
+     */
+    public function setNegativ($negativ);
+
+    /**
+     * Get negativ.
+     *
+     * @return bool
+     */
+    public function getNegativ();
+
+    /**
+     * Set submitted.
+     *
+     * @param bool $submitted
+     *
+     * @return DraftStatementInterface
+     */
+    public function setSubmitted($submitted);
+
+    /**
+     * Get submitted.
+     *
+     * @return bool
+     */
+    public function isSubmitted();
+
+    /**
+     * Set released.
+     *
+     * @param bool $released
+     *
+     * @return DraftStatementInterface
+     */
+    public function setReleased($released);
+
+    /**
+     * Get released.
+     *
+     * @return bool
+     */
+    public function isReleased();
+
+    /**
+     * Set showToAll.
+     *
+     * @param bool $showToAll
+     *
+     * @return DraftStatementInterface
+     */
+    public function setShowToAll($showToAll);
+
+    /**
+     * Get showToAll.
+     *
+     * @return bool
+     */
+    public function isShowToAll();
+
+    /**
+     * Set deleted.
+     *
+     * @param bool $deleted
+     *
+     * @return DraftStatementInterface
+     */
+    public function setDeleted($deleted);
+
+    /**
+     * Get deleted.
+     *
+     * @return bool
+     */
+    public function isDeleted();
+
+    /**
+     * Tells Elasticsearch whether Entity should be indexed.
+     *
+     * @return bool
+     */
+    public function shouldBeIndexed();
+
+    /**
+     * Set rejected.
+     *
+     * @param bool $rejected
+     *
+     * @return DraftStatementInterface
+     */
+    public function setRejected($rejected);
+
+    /**
+     * Get rejected.
+     *
+     * @return bool
+     */
+    public function isRejected();
+
+    /**
+     * Set publicAllowed.
+     *
+     * @param bool $publicAllowed
+     *
+     * @return DraftStatementInterface
+     */
+    public function setPublicAllowed($publicAllowed);
+
+    public function isPublicAllowed(): bool;
+
+    /**
+     * Set publicUseName.
+     *
+     * @param bool $publicUseName
+     *
+     * @return DraftStatementInterface
+     */
+    public function setPublicUseName($publicUseName);
+
+    /**
+     * Get publicUseName.
+     *
+     * @return bool
+     */
+    public function isPublicUseName();
+
+    /**
+     * Set publicDraftStatement.
+     *
+     * @param string $publicDraftStatement
+     *
+     * @return DraftStatementInterface
+     */
+    public function setPublicDraftStatement($publicDraftStatement);
+
+    /**
+     * Get publicDraftStatement.
+     *
+     * @return string
+     */
+    public function getPublicDraftStatement();
+
+    /**
+     * Returns a text that describes in the name of whom this
+     * statement is going to be submitted.
+     *
+     * @return string
+     */
+    public function getRepresents();
+
+    /**
+     * Sets a text that describes in the name of whom this
+     * statement is going to be submitted.
+     *
+     * @param string $represents
+     *
+     * @return DraftStatementInterface
+     */
+    public function setRepresents($represents);
+
+    /**
+     * Set phase.
+     *
+     * @param string $phase
+     *
+     * @return DraftStatementInterface
+     */
+    public function setPhase($phase);
+
+    /**
+     * Get phase.
+     *
+     * @return string
+     */
+    public function getPhase();
+
+    /**
+     * Set createdDate.
+     *
+     * @param DateTime $createdDate
+     *
+     * @return DraftStatementInterface
+     */
+    public function setCreatedDate($createdDate);
+
+    /**
+     * Get createdDate.
+     *
+     * @return DateTime
+     */
+    public function getCreatedDate();
+
+    /**
+     * Set deletedDate.
+     *
+     * @param DateTime $deletedDate
+     *
+     * @return DraftStatementInterface
+     */
+    public function setDeletedDate($deletedDate);
+
+    /**
+     * Get deletedDate.
+     *
+     * @return DateTime
+     */
+    public function getDeletedDate();
+
+    /**
+     * Set lastModifiedDate.
+     *
+     * @param DateTime $lastModifiedDate
+     *
+     * @return DraftStatementInterface
+     */
+    public function setLastModifiedDate($lastModifiedDate);
+
+    /**
+     * Get lastModifiedDate.
+     *
+     * @return DateTime
+     */
+    public function getLastModifiedDate();
+
+    /**
+     * Set submittedDate.
+     *
+     * @param DateTime $submittedDate
+     *
+     * @return DraftStatementInterface
+     */
+    public function setSubmittedDate($submittedDate);
+
+    /**
+     * Get submittedDate.
+     *
+     * @return DateTime
+     */
+    public function getSubmittedDate();
+
+    /**
+     * Set releasedDate.
+     *
+     * @param DateTime $releasedDate
+     *
+     * @return DraftStatementInterface
+     */
+    public function setReleasedDate($releasedDate);
+
+    /**
+     * Get releasedDate.
+     *
+     * @return DateTime
+     */
+    public function getReleasedDate();
+    /**
+     * Set rejectedDate.
+     *
+     * @param DateTime $rejectedDate
+     *
+     * @return DraftStatementInterface
+     */
+    public function setRejectedDate($rejectedDate);
+
+    /**
+     * Get rejectedDate.
+     *
+     * @return DateTime
+     */
+    public function getRejectedDate();
+
+    /**
+     * Get statementAttributes.
+     *
+     * @return StatementAttributeInterface[]
+     */
+    public function getStatementAttributes();
+
+    /**
+     * Reset statementAttributes.
+     */
+    public function clearStatementAttributes();
+
+    /**
+     * Get statementAttributes of one type.
+     *
+     * @param string $type
+     *
+     * @return array|string
+     */
+    public function getStatementAttributesByType($type);
+
+    /**
+     * Add StatementAttribute to DraftStatement.
+     *
+     * @param StatementAttributeInterface $statementAttribute
+     */
+    public function addStatementAttribute(StatementAttributeInterface $statementAttribute);
+
+    /**
+     * Remove StatementAttribute from DraftStatement.
+     *
+     * @param StatementAttributeInterface $statementAttribute
+     */
+    public function removeStatementAttribute(StatementAttributeInterface $statementAttribute);
+
+    /**
+     * @param string $key
+     *
+     * @return mixed|null
+     */
+    public function getMiscDataValue($key);
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return DraftStatementInterface
+     */
+    public function setMiscDataValue($key, $value);
+
+    /**
+     * @return array
+     */
+    public function getMiscData();
+
+    /**
+     * @param string $miscData
+     */
+    public function setMiscData($miscData);
+
+    public function getHouseNumber(): string;
+
+    public function setHouseNumber(string $houseNumber);
+
+    public function isAnonymous(): bool;
+
+    public function setAnonymous(bool $anonymous): void;
+}

--- a/src/Contracts/Entities/ExportFieldsConfigurationInterface.php
+++ b/src/Contracts/Entities/ExportFieldsConfigurationInterface.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface ExportFieldsConfigurationInterface extends UuidEntityInterface
+{
+    public function isIdExportable(): bool;
+
+    public function setIdExportable(bool $idExportable): void;
+    public function isStatementNameExportable(): bool;
+
+    public function setStatementNameExportable(bool $statementNameExportable): void;
+
+    public function isCreationDateExportable(): bool;
+
+    public function setCreationDateExportable(bool $creationDateExportable): void;
+
+    public function isProcedureNameExportable(): bool;
+
+    public function setProcedureNameExportable(bool $procedureNameExportable): void;
+
+    public function isProcedurePhaseExportable(): bool;
+
+    public function setProcedurePhaseExportable(bool $procedurePhaseExportable): void;
+
+    public function isVotesNumExportable(): bool;
+
+    public function setVotesNumExportable(bool $votesNumExportable): void;
+
+    public function isUserStateExportable(): bool;
+
+    public function setUserStateExportable(bool $userStateExportable): void;
+
+    public function isUserGroupExportable(): bool;
+
+    public function setUserGroupExportable(bool $userGroupExportable): void;
+
+    public function isUserOrganisationExportable(): bool;
+
+    public function setUserOrganisationExportable(bool $userOrganisationExportable): void;
+
+    public function isUserPositionExportable(): bool;
+
+    public function setUserPositionExportable(bool $userPositionExportable): void;
+
+    public function isInstitutionExportable(): bool;
+
+    public function setInstitutionExportable(bool $institutionExportable): void;
+
+    public function isPublicParticipationExportable(): bool;
+
+    public function setPublicParticipationExportable(bool $publicParticipationExportable): void;
+
+    public function isOrgaNameExportable(): bool;
+
+    public function setOrgaNameExportable(bool $orgaNameExportable): void;
+
+    public function isDepartmentNameExportable(): bool;
+
+    public function setDepartmentNameExportable(bool $departmentNameExportable): void;
+
+    public function isSubmitterNameExportable(): bool;
+
+    public function setSubmitterNameExportable(bool $submitterNameExportable): void;
+
+    public function isShowInPublicAreaExportable(): bool;
+
+    public function setShowInPublicAreaExportable(bool $showInPublicAreaExportable): void;
+
+    public function isDocumentExportable(): bool;
+
+    public function setDocumentExportable(bool $documentExportable): void;
+
+    public function isParagraphExportable(): bool;
+
+    public function setParagraphExportable(bool $paragraphExportable): void;
+
+    public function isFilesExportable(): bool;
+
+    public function setFilesExportable(bool $filesExportable): void;
+
+    public function isAttachmentsExportable(): bool;
+
+    public function setAttachmentsExportable(bool $attachmentsExportable): void;
+
+    public function isPriorityExportable(): bool;
+
+    public function setPriorityExportable(bool $priorityExportable): void;
+
+    public function isEmailExportable(): bool;
+
+    public function setEmailExportable(bool $emailExportable): void;
+
+    public function isPhoneNumberExportable(): bool;
+
+    public function setPhoneNumberExportable(bool $phoneNumberExportable): void;
+
+    public function isStreetExportable(): bool;
+
+    public function setStreetExportable(bool $streetExportable): void;
+
+    public function isStreetNumberExportable(): bool;
+
+    public function setStreetNumberExportable(bool $streetNumberExportable): void;
+
+    public function isPostalCodeExportable(): bool;
+
+    public function setPostalCodeExportable(bool $postalCodeExportable): void;
+
+    public function isCityExportable(): bool;
+
+    public function setCityExportable(bool $cityExportable): void;
+
+    public function isInstitutionOrCitizenExportable(): bool;
+
+    public function setInstitutionOrCitizenExportable(bool $institutionOrCitizenExportable): void;
+
+    public function getId(): ?string;
+
+    public function getProcedure(): ProcedureInterface;
+
+    public function getCreationDate(): DateTime;
+
+    public function getModificationDate(): DateTime;
+
+    public function initializeAllProperties(bool $value): void;
+}

--- a/src/Contracts/Entities/ExportFieldsConfigurationInterface.php
+++ b/src/Contracts/Entities/ExportFieldsConfigurationInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface ExportFieldsConfigurationInterface extends UuidEntityInterface
+interface ExportFieldsConfigurationInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function isIdExportable(): bool;
 
@@ -116,8 +116,6 @@ interface ExportFieldsConfigurationInterface extends UuidEntityInterface
     public function isInstitutionOrCitizenExportable(): bool;
 
     public function setInstitutionOrCitizenExportable(bool $institutionOrCitizenExportable): void;
-
-    public function getId(): ?string;
 
     public function getProcedure(): ProcedureInterface;
 

--- a/src/Contracts/Entities/FileContainerInterface.php
+++ b/src/Contracts/Entities/FileContainerInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface FileContainerInterface extends UuidEntityInterface
+interface FileContainerInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @param string $id

--- a/src/Contracts/Entities/FileContainerInterface.php
+++ b/src/Contracts/Entities/FileContainerInterface.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface FileContainerInterface extends UuidEntityInterface
+{
+    /**
+     * @param string $id
+     */
+    public function setId($id);
+
+    /**
+     * @return string
+     */
+    public function getEntityId();
+
+    /**
+     * @param string $entityId
+     */
+    public function setEntityId($entityId);
+
+    /**
+     * @return string
+     */
+    public function getEntityField();
+
+    /**
+     * @param string $entityField
+     */
+    public function setEntityField($entityField);
+
+    /**
+     * @return string
+     */
+    public function getEntityClass();
+
+    /**
+     * @param string $entityClass
+     */
+    public function setEntityClass($entityClass);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreateDate();
+
+    /**
+     * @param DateTime $createDate
+     */
+    public function setCreateDate($createDate);
+
+    /**
+     * @return DateTime
+     */
+    public function getModifyDate();
+
+    /**
+     * @param DateTime $modifyDate
+     */
+    public function setModifyDate($modifyDate);
+
+    /**
+     * @return int
+     */
+    public function getOrder();
+
+    /**
+     * @param int $order
+     */
+    public function setOrder($order);
+
+    /**
+     * @return string
+     */
+    public function getFileString();
+
+    /**
+     * @param string $fileString
+     */
+    public function setFileString($fileString);
+
+    /**
+     * @return FileInterface
+     */
+    public function getFile();
+
+    /**
+     * @param FileInterface $file
+     */
+    public function setFile($file);
+
+    /**
+     * @param bool $publicAllowed
+     *
+     * @return $this
+     */
+    public function setPublicAllowed($publicAllowed);
+
+    /**
+     * @return bool
+     */
+    public function getPublicAllowed();
+
+}

--- a/src/Contracts/Entities/FileInterface.php
+++ b/src/Contracts/Entities/FileInterface.php
@@ -18,9 +18,6 @@ interface FileInterface extends UuidEntityInterface, CoreEntityInterface
      */
     public function setIdent($ident);
 
-    /**
-     * @deprecated use {@link FileInterface::getId()} instead
-     */
     public function getIdent(): ?string;
 
     /**

--- a/src/Contracts/Entities/FileInterface.php
+++ b/src/Contracts/Entities/FileInterface.php
@@ -18,8 +18,6 @@ interface FileInterface extends UuidEntityInterface, CoreEntityInterface
      */
     public function setIdent($ident);
 
-    public function getIdent(): ?string;
-
     /**
      * @param string $hash
      *

--- a/src/Contracts/Entities/GdprConsentInterface.php
+++ b/src/Contracts/Entities/GdprConsentInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface GdprConsentInterface extends UuidEntityInterface
+{
+    public function setId(string $id);
+
+    /**
+     * @return DateTime|null
+     */
+    public function getConsentReceivedDate();
+
+    /**
+     * @param DateTime|null $consentReceivedDate
+     */
+    public function setConsentReceivedDate($consentReceivedDate);
+
+    /**
+     * @return DateTime|null
+     */
+    public function getConsentRevokedDate();
+
+    /**
+     * @param DateTime|null $date
+     */
+    public function setConsentRevokedDate($date);
+
+    /**
+     * @return UserInterface|null
+     */
+    public function getConsentee();
+
+    /**
+     * @param UserInterface|null $consentee
+     */
+    public function setConsentee($consentee);
+
+    /**
+     * @return StatementInterface
+     */
+    public function getStatement();
+
+    /**
+     * @throws InvalidDataException
+     */
+    public function setStatement(StatementInterface $statement);
+
+    public function isConsented(): bool;
+
+    public function isConsentReceived(): bool;
+
+    public function setConsentReceived(bool $consentReceived);
+
+    public function isConsentRevoked(): bool;
+
+    public function setConsentRevoked(bool $consentRevoked);
+
+    /**
+     * @return bool true if the consent was given regarding the author data of the statement
+     */
+    public function isConsentedToAuthorData(): bool;
+
+    /**
+     * @return bool true if the consent was given regarding the submitter data of the statement
+     */
+    public function isConsentedToSubmitterData(): bool;
+
+}

--- a/src/Contracts/Entities/GdprConsentInterface.php
+++ b/src/Contracts/Entities/GdprConsentInterface.php
@@ -43,9 +43,6 @@ interface GdprConsentInterface extends UuidEntityInterface
      */
     public function getStatement();
 
-    /**
-     * @throws InvalidDataException
-     */
     public function setStatement(StatementInterface $statement);
 
     public function isConsented(): bool;

--- a/src/Contracts/Entities/GdprConsentInterface.php
+++ b/src/Contracts/Entities/GdprConsentInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface GdprConsentInterface extends UuidEntityInterface
+interface GdprConsentInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function setId(string $id);
 

--- a/src/Contracts/Entities/GisLayerInterface.php
+++ b/src/Contracts/Entities/GisLayerInterface.php
@@ -8,6 +8,10 @@ use DateTime;
 
 interface GisLayerInterface extends UuidEntityInterface, CoreEntityInterface
 {
+
+    public const TYPE_BASE = 'base';
+    public const TYPE_OVERLAY = 'overlay';
+
     public function set($data);
 
     /**
@@ -16,8 +20,6 @@ interface GisLayerInterface extends UuidEntityInterface, CoreEntityInterface
      * @return array
      */
     public function toArray();
-
-    public function getIdent(): ?string;
 
     /**
      * @param string $ident

--- a/src/Contracts/Entities/GisLayerInterface.php
+++ b/src/Contracts/Entities/GisLayerInterface.php
@@ -6,7 +6,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface GisLayerInterface extends UuidEntityInterface
+interface GisLayerInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function set($data);
 
@@ -17,9 +17,6 @@ interface GisLayerInterface extends UuidEntityInterface
      */
     public function toArray();
 
-    /**
-     * @deprecated use {@link GisLayerInterface::getId()} instead
-     */
     public function getIdent(): ?string;
 
     /**

--- a/src/Contracts/Entities/InstitutionTagInterface.php
+++ b/src/Contracts/Entities/InstitutionTagInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use DateTime;
 use Doctrine\Common\Collections\Collection;
 
-interface InstitutionTagInterface extends UuidEntityInterface
+interface InstitutionTagInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function getOwningOrganisation(): OrgaInterface;
 

--- a/src/Contracts/Entities/MasterToebInterface.php
+++ b/src/Contracts/Entities/MasterToebInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use DateTime;
 use DateTimeInterface;
 
-interface MasterToebInterface extends UuidEntityInterface
+interface MasterToebInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @return mixed

--- a/src/Contracts/Entities/MunicipalityInterface.php
+++ b/src/Contracts/Entities/MunicipalityInterface.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use League\Fractal\Resource\ArrayCollection;
+
+interface MunicipalityInterface extends UuidEntityInterface
+{
+    /**
+     * Return name in addition of officialMunicipalityKey if officialMunicipalityKey is set.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @param string $name
+     */
+    public function setName($name);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getStatements();
+
+    /**
+     * @param ArrayCollection $statements
+     */
+    public function setStatements($statements);
+
+    /**
+     * Add Statement.
+     *
+     * @param StatementInterface $statement
+     *
+     * @return bool - true if the given statement was added to this municipality, otherwise false
+     */
+    public function addStatement($statement);
+
+    /**
+     * Remove Statement.
+     *
+     * @param StatementInterface $statement
+     */
+    public function removeStatement($statement);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getStatementFragments();
+
+    /**
+     * Add StatementFragment.
+     *
+     * @param StatementFragmentInterface $fragment
+     */
+    public function addStatementFragment($fragment);
+
+    /**
+     * Remove StatementFragment.
+     *
+     * @param StatementFragmentInterface $fragment
+     */
+    public function removeStatementFragment($fragment);
+
+    /**
+     * @param string|null $officialMunicipalityKey
+     */
+    public function setOfficialMunicipalityKey($officialMunicipalityKey);
+
+    /**
+     * @return string|null
+     */
+    public function getOfficialMunicipalityKey();
+}

--- a/src/Contracts/Entities/MunicipalityInterface.php
+++ b/src/Contracts/Entities/MunicipalityInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-interface MunicipalityInterface extends UuidEntityInterface
+interface MunicipalityInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * Return name in addition of officialMunicipalityKey if officialMunicipalityKey is set.

--- a/src/Contracts/Entities/MunicipalityInterface.php
+++ b/src/Contracts/Entities/MunicipalityInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 interface MunicipalityInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/NotificationReceiverInterface.php
+++ b/src/Contracts/Entities/NotificationReceiverInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface NotificationReceiverInterface extends UuidEntityInterface
+{
+    /**
+     * @param string $id
+     */
+    public function setId($id);
+
+    /**
+     * @return string
+     */
+    public function getLabel();
+
+    /**
+     * @param string $label
+     */
+    public function setLabel($label);
+
+    /**
+     * @return string
+     */
+    public function getProcedure();
+
+    /**
+     * @param ProcedureInterface $procedure
+     */
+    public function setProcedure($procedure);
+
+    /**
+     * @return string
+     */
+    public function getEmail();
+
+    /**
+     * @param string $email
+     */
+    public function setEmail($email);
+}

--- a/src/Contracts/Entities/NotificationReceiverInterface.php
+++ b/src/Contracts/Entities/NotificationReceiverInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface NotificationReceiverInterface extends UuidEntityInterface
+interface NotificationReceiverInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @param string $id

--- a/src/Contracts/Entities/OrgaStatusInCustomerInterface.php
+++ b/src/Contracts/Entities/OrgaStatusInCustomerInterface.php
@@ -3,7 +3,7 @@
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 
-interface OrgaStatusInCustomerInterface extends UuidEntityInterface
+interface OrgaStatusInCustomerInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const STATUS_PENDING = 'pending';
 

--- a/src/Contracts/Entities/OrgaStatusInCustomerInterface.php
+++ b/src/Contracts/Entities/OrgaStatusInCustomerInterface.php
@@ -4,5 +4,27 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 interface OrgaStatusInCustomerInterface extends UuidEntityInterface
 {
+    public const STATUS_PENDING = 'pending';
 
+    public const STATUS_ACCEPTED = 'accepted';
+    
+    public const STATUS_REJECTED = 'rejected';
+
+    public function setId(string $id);
+
+    public function getOrga(): OrgaInterface;
+
+    public function setOrga(OrgaInterface $orga);
+
+    public function getOrgaType(): OrgaTypeInterface;
+
+    public function setOrgaType(OrgaTypeInterface $orgaType);
+
+    public function getCustomer(): CustomerInterface;
+
+    public function setCustomer(CustomerInterface $customer);
+
+    public function getStatus(): string;
+
+    public function setStatus(string $status);
 }

--- a/src/Contracts/Entities/OrgaStatusInCustomerInterface.php
+++ b/src/Contracts/Entities/OrgaStatusInCustomerInterface.php
@@ -2,12 +2,13 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+
 interface OrgaStatusInCustomerInterface extends UuidEntityInterface
 {
     public const STATUS_PENDING = 'pending';
 
     public const STATUS_ACCEPTED = 'accepted';
-    
+
     public const STATUS_REJECTED = 'rejected';
 
     public function setId(string $id);

--- a/src/Contracts/Entities/OrgaTypeInterface.php
+++ b/src/Contracts/Entities/OrgaTypeInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\Collection;
 
 interface OrgaTypeInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/OrgaTypeInterface.php
+++ b/src/Contracts/Entities/OrgaTypeInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use Doctrine\Common\Collections\Collection;
 
-interface OrgaTypeInterface extends UuidEntityInterface
+interface OrgaTypeInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * AHB = Anhörungsbehörde = hearing authority.

--- a/src/Contracts/Entities/OrgaTypeInterface.php
+++ b/src/Contracts/Entities/OrgaTypeInterface.php
@@ -2,7 +2,80 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use League\Fractal\Resource\Collection;
+
 interface OrgaTypeInterface extends UuidEntityInterface
 {
+    /**
+     * AHB = Anhörungsbehörde = hearing authority.
+     *
+     * @const string Denotes a hearing authority agency
+     */
+    public const HEARING_AUTHORITY_AGENCY = 'OHAUTH';
 
+    /**
+     * @const string Denotes a public agency (Institution)
+     */
+    public const PUBLIC_AGENCY = 'OPSORG';
+
+    /**
+     * @const string Denotes a planning agency (Planungsbüro)
+     */
+    public const PLANNING_AGENCY = 'OPAUTH';
+
+    /**
+     * @const string Denotes a municipality (Fachplaner)
+     */
+    public const MUNICIPALITY = 'OLAUTH';
+
+    /**
+     * @const string Default orga type when no other fits
+     */
+    public const DEFAULT = 'OTDEFA';
+
+    public const ORGATYPE_ROLE = [
+        self::PUBLIC_AGENCY            => [
+            RoleInterface::PUBLIC_AGENCY_COORDINATION,
+            RoleInterface::PUBLIC_AGENCY_WORKER,
+        ],
+        self::MUNICIPALITY             => [
+            RoleInterface::PLANNING_AGENCY_ADMIN,
+            RoleInterface::PLANNING_AGENCY_WORKER,
+        ],
+        self::PLANNING_AGENCY          => [
+            RoleInterface::PRIVATE_PLANNING_AGENCY,
+        ],
+        self::HEARING_AUTHORITY_AGENCY => [
+            RoleInterface::HEARING_AUTHORITY_ADMIN,
+            RoleInterface::HEARING_AUTHORITY_WORKER,
+        ],
+    ];
+
+    /**
+     * Set otName.
+     *
+     * @param string $name
+     */
+    public function setName($name);
+
+    public function getName(): string;
+
+    /**
+     * Set otLabel.
+     *
+     * @param string $label
+     */
+    public function setLabel($label);
+
+    public function getLabel(): string;
+
+    /**
+     * @return Collection<int, OrgaStatusInCustomerInterface>
+     */
+    public function getOrgaStatusInCustomers();
+
+    /**
+     * @param Collection<int, OrgaStatusInCustomerInterface> $orgaStatusInCustomers
+     */
+    public function setOrgaStatusInCustomers(Collection $orgaStatusInCustomers);
 }

--- a/src/Contracts/Entities/OriginalStatementAnonymizationInterface.php
+++ b/src/Contracts/Entities/OriginalStatementAnonymizationInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface OriginalStatementAnonymizationInterface
+{
+    public function getCreated(): DateTime;
+
+    public function isAttachmentsDeleted(): bool;
+
+    public function setAttachmentsDeleted(bool $attachmentsDeleted): void;
+
+    public function isTextVersionHistoryDeleted(): bool;
+
+    public function setTextVersionHistoryDeleted(bool $textVersionHistoryDeleted): void;
+
+    public function isTextPassagesAnonymized(): bool;
+
+    public function setTextPassagesAnonymized(bool $textPassagesAnonymized): void;
+
+    public function getStatement(): StatementInterface;
+
+    public function setStatement(StatementInterface $statement): void;
+
+    public function getCreatedBy(): UserInterface;
+
+    public function setCreatedBy(UserInterface $createdBy): void;
+
+    public function isSubmitterAndAuthorMetaDataAnonymized(): bool;
+
+    public function setSubmitterAndAuthorMetaDataAnonymized(bool $submitterAndAuthorMetaDataAnonymized): void;
+
+}

--- a/src/Contracts/Entities/OriginalStatementAnonymizationInterface.php
+++ b/src/Contracts/Entities/OriginalStatementAnonymizationInterface.php
@@ -6,6 +6,7 @@ use DateTime;
 
 interface OriginalStatementAnonymizationInterface
 {
+    public function getId(): string;
     public function getCreated(): DateTime;
 
     public function isAttachmentsDeleted(): bool;

--- a/src/Contracts/Entities/ParagraphInterface.php
+++ b/src/Contracts/Entities/ParagraphInterface.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+use League\Fractal\Resource\Collection;
+
+interface ParagraphInterface extends UuidEntityInterface
+{
+    public function getParent(): ?self;
+
+    /**
+     * @return $this
+     */
+    public function setParent(?ParagraphInterface $parent): self;
+
+    /**
+     * @return ParagraphInterface[]
+     */
+    public function getChildren(): array;
+
+    /**
+     * @param ParagraphInterface[] $children
+     *
+     * @return $this
+     */
+    public function setChildren(array $children): self;
+
+    /**
+     * @return $this
+     */
+    public function addChild(ParagraphInterface $child): self;
+
+    /**
+     * @return $this
+     */
+    public function removeChild(ParagraphInterface $child): self;
+
+    /**
+     * Set procedure.
+     */
+    public function setProcedure(ProcedureInterface $procedure): self;
+
+    /**
+     * Get procedure.
+     */
+    public function getProcedure(): ProcedureInterface;
+
+    /**
+     * Get pId.
+     *
+     * @return string
+     */
+    public function getPId();
+
+    /**
+     * Get elementId.
+     *
+     * @return string
+     */
+    public function getElementId();
+
+    public function getElement(): ElementsInterface;
+
+    public function setElement(ElementsInterface $element): void;
+
+    /**
+     * Set eCategory.
+     */
+    public function setCategory(string $category): self;
+
+    /**
+     * Get eCategory.
+     */
+    public function getCategory(): string;
+
+    /**
+     * Set eTitle.
+     */
+    public function setTitle(string $title): self;
+
+    /**
+     * Get eTitle.
+     */
+    public function getTitle(): string;
+
+    /**
+     * Set eText.
+     */
+    public function setText(string $text): self;
+
+    /**
+     * Get eText.
+     */
+    public function getText(): string;
+
+    /**
+     * Set eOrder.
+     */
+    public function setOrder(int $order): self;
+
+    /**
+     * Get eOrder.
+     */
+    public function getOrder(): int;
+
+    /**
+     * Set eEnabled.
+     */
+    public function setVisible(int $visible): self;
+
+    /**
+     * Get eEnabled.
+     */
+    public function getVisible(): int;
+
+    /**
+     * Set eDeleted.
+     */
+    public function setDeleted(bool $deleted): self;
+
+    /**
+     * Get eDeleted.
+     */
+    public function getDeleted(): bool;
+
+    /**
+     * Set lockReason.
+     */
+    public function setLockReason(string $lockReason): self;
+
+    /**
+     * Get lockReason.
+     */
+    public function getLockReason(): string;
+
+    /**
+     * Set eCreateDate.
+     */
+    public function setCreateDate(DateTime $createDate): self;
+
+    /**
+     * Get eCreateDate.
+     */
+    public function getCreateDate(): DateTime;
+
+    /**
+     * Set eModifyDate.
+     */
+    public function setModifyDate(DateTime $modifyDate): self;
+
+    /**
+     * Get eModifyDate.
+     */
+    public function getModifyDate(): DateTime;
+
+    /**
+     * Set eDeleteDate.
+     */
+    public function setDeleteDate(DateTime $deleteDate): self;
+
+    /**
+     * Get eDeleteDate.
+     */
+    public function getDeleteDate(): DateTime;
+
+    /**
+     * @return Collection<int, ParagraphVersionInterface>
+     */
+    public function getVersions(): Collection;
+
+}

--- a/src/Contracts/Entities/ParagraphInterface.php
+++ b/src/Contracts/Entities/ParagraphInterface.php
@@ -3,7 +3,7 @@
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\Collection;
 
 interface ParagraphInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/ParagraphInterface.php
+++ b/src/Contracts/Entities/ParagraphInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use DateTime;
 use Doctrine\Common\Collections\Collection;
 
-interface ParagraphInterface extends UuidEntityInterface
+interface ParagraphInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function getParent(): ?self;
 

--- a/src/Contracts/Entities/ParagraphVersionInterface.php
+++ b/src/Contracts/Entities/ParagraphVersionInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface ParagraphVersionInterface extends UuidEntityInterface
+interface ParagraphVersionInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * Get elementId.

--- a/src/Contracts/Entities/ParagraphVersionInterface.php
+++ b/src/Contracts/Entities/ParagraphVersionInterface.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface ParagraphVersionInterface extends UuidEntityInterface
+{
+    /**
+     * Get elementId.
+     *
+     * @return string
+     */
+    public function getElementId();
+
+    /**
+     * @return ElementsInterface|null
+     */
+    public function getElement();
+
+    /**
+     * @param ElementsInterface $element
+     */
+    public function setElement($element);
+
+    /**
+     * @return ParagraphInterface
+     */
+    public function getParagraph();
+
+    /**
+     * @param ParagraphInterface $paragraph
+     */
+    public function setParagraph($paragraph);
+
+    /**
+     * Set procedure.
+     *
+     * @param ProcedureInterface $procedure
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setProcedure($procedure);
+
+    /**
+     * Get procedure.
+     *
+     * @return ProcedureInterface
+     */
+    public function getProcedure();
+
+    /**
+     * Get procedureId.
+     *
+     * @return string
+     */
+    public function getPId();
+
+    /**
+     * Set eCategory.
+     *
+     * @param string $category
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setCategory($category);
+
+    /**
+     * Get eCategory.
+     *
+     * @return string
+     */
+    public function getCategory();
+
+    /**
+     * Set eTitle.
+     *
+     * @param string $title
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setTitle($title);
+
+    /**
+     * Get eTitle.
+     */
+    public function getTitle(): string;
+
+    /**
+     * Set eText.
+     *
+     * @param string $text
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setText($text);
+
+    /**
+     * Get eText.
+     *
+     * @return string
+     */
+    public function getText();
+
+    /**
+     * Set eOrder.
+     *
+     * @param int $order
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setOrder($order);
+
+    /**
+     * Get eOrder.
+     *
+     * @return int
+     */
+    public function getOrder();
+
+    /**
+     * Set eEnabled.
+     *
+     * @param bool $visible
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setVisible($visible);
+
+    /**
+     * Get eEnabled.
+     *
+     * @return bool
+     */
+    public function getVisible();
+
+    /**
+     * Set eDeleted.
+     *
+     * @param bool $deleted
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setDeleted($deleted);
+
+    /**
+     * Get eDeleted.
+     *
+     * @return bool
+     */
+    public function getDeleted();
+
+    /**
+     * Set eCreateDate.
+     *
+     * @param DateTime $createDate
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setCreateDate($createDate);
+
+    /**
+     * Get eCreateDate.
+     *
+     * @return DateTime
+     */
+    public function getCreateDate();
+
+    /**
+     * Set eModifyDate.
+     *
+     * @param DateTime $modifyDate
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setModifyDate($modifyDate);
+
+    /**
+     * Get eModifyDate.
+     *
+     * @return DateTime
+     */
+    public function getModifyDate();
+
+    /**
+     * Set eDeleteDate.
+     *
+     * @param DateTime $deleteDate
+     *
+     * @return ParagraphVersionInterface
+     */
+    public function setDeleteDate($deleteDate);
+
+    /**
+     * Get eDeleteDate.
+     *
+     * @return DateTime
+     */
+    public function getDeleteDate();
+
+}

--- a/src/Contracts/Entities/PlaceInterface.php
+++ b/src/Contracts/Entities/PlaceInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface PlaceInterface
+{
+    public function getName(): string;
+
+    public function setName(string $name): self;
+
+    public function setSortIndex(int $sortIndex): self;
+
+    public function getSortIndex(): int;
+
+    public function getProcedure(): ProcedureInterface;
+
+    public function getDescription(): string;
+
+    public function setDescription(string $description);
+
+}

--- a/src/Contracts/Entities/PlaceInterface.php
+++ b/src/Contracts/Entities/PlaceInterface.php
@@ -2,8 +2,9 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface PlaceInterface
+interface PlaceInterface extends CoreEntityInterface
 {
+    public function getId(): ?string;
     public function getName(): string;
 
     public function setName(string $name): self;

--- a/src/Contracts/Entities/PriorityAreaInterface.php
+++ b/src/Contracts/Entities/PriorityAreaInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-interface PriorityAreaInterface extends UuidEntityInterface
+interface PriorityAreaInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @return string

--- a/src/Contracts/Entities/PriorityAreaInterface.php
+++ b/src/Contracts/Entities/PriorityAreaInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 interface PriorityAreaInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/PriorityAreaInterface.php
+++ b/src/Contracts/Entities/PriorityAreaInterface.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use League\Fractal\Resource\ArrayCollection;
+
+interface PriorityAreaInterface extends UuidEntityInterface
+{
+    /**
+     * @return string
+     */
+    public function getKey();
+
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @param string $key
+     */
+    public function setKey($key);
+
+    /**
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * @param string $type
+     */
+    public function setType($type);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getStatements();
+
+    /**
+     * @param ArrayCollection $statements
+     */
+    public function setStatements($statements);
+
+    /**
+     * Add Statement.
+     *
+     * @param StatementInterface $statement
+     *
+     * @return bool - true if the given statement was added to this priorityArea, otherwise false
+     */
+    public function addStatement($statement);
+
+    /**
+     * Remove Statement.
+     *
+     * @param StatementInterface $statement
+     */
+    public function removeStatement($statement);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getStatementFragments();
+
+    /**
+     * Add StatementFragment.
+     *
+     * @param StatementFragmentInterface $fragment
+     */
+    public function addStatementFragment($fragment);
+
+    /**
+     * Remove StatementFragment.
+     *
+     * @param StatementFragmentInterface $fragment
+     */
+    public function removeStatementFragment($fragment);
+
+}

--- a/src/Contracts/Entities/ProcedureBehaviorDefinitionInterface.php
+++ b/src/Contracts/Entities/ProcedureBehaviorDefinitionInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface ProcedureBehaviorDefinitionInterface extends UuidEntityInterface
+{
+    public function getProcedure(): ?ProcedureInterface;
+
+    public function setProcedure(ProcedureInterface $procedure): void;
+
+    public function getProcedureType(): ?ProcedureTypeInterface;
+
+    public function setProcedureType(ProcedureTypeInterface $procedureType): void;
+
+    public function isAllowedToEnableMap(): bool;
+
+    public function setAllowedToEnableMap(bool $allowedToEnableMap): void;
+
+    public function hasPriorityArea(): bool;
+
+    public function setHasPriorityArea(bool $hasPriorityArea): void;
+
+    public function isParticipationGuestOnly(): bool;
+
+    public function setParticipationGuestOnly(bool $participationGuestOnly): void;
+
+    public function getCreationDate(): DateTime;
+
+    public function getModificationDate(): DateTime;
+
+}

--- a/src/Contracts/Entities/ProcedureBehaviorDefinitionInterface.php
+++ b/src/Contracts/Entities/ProcedureBehaviorDefinitionInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface ProcedureBehaviorDefinitionInterface extends UuidEntityInterface
+interface ProcedureBehaviorDefinitionInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function getProcedure(): ?ProcedureInterface;
 

--- a/src/Contracts/Entities/ProcedureCategoryInterface.php
+++ b/src/Contracts/Entities/ProcedureCategoryInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface ProcedureCategoryInterface extends UuidEntityInterface
+interface ProcedureCategoryInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @return $this

--- a/src/Contracts/Entities/ProcedureCategoryInterface.php
+++ b/src/Contracts/Entities/ProcedureCategoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface ProcedureCategoryInterface extends UuidEntityInterface
+{
+    /**
+     * @return $this
+     */
+    public function setId(string $id): self;
+
+    /**
+     * Set name.
+     */
+    public function setName(string $name): self;
+
+    /**
+     * Get name.
+     */
+    public function getName(): string;
+
+    public function getSlug(): string;
+
+    public function setSlug(string $slug): void;
+
+}

--- a/src/Contracts/Entities/ProcedureInterface.php
+++ b/src/Contracts/Entities/ProcedureInterface.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use DateTime;
 
-interface ProcedureInterface
+interface ProcedureInterface extends SluggedEntityInterface
 {
     public const VALIDATION_GROUP_MANDATORY_PROCEDURE = 'mandatory_procedure';
 

--- a/src/Contracts/Entities/ProcedureInterface.php
+++ b/src/Contracts/Entities/ProcedureInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\Collection;
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use DateTime;
 
 interface ProcedureInterface

--- a/src/Contracts/Entities/ProcedureInterface.php
+++ b/src/Contracts/Entities/ProcedureInterface.php
@@ -4,7 +4,942 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\ArrayCollection;
+use DateTime;
+
 interface ProcedureInterface
 {
+    public const VALIDATION_GROUP_MANDATORY_PROCEDURE = 'mandatory_procedure';
+
+    public const VALIDATION_GROUP_MANDATORY_PROCEDURE_TEMPLATE = 'mandatory_procedure_template';
+
+    // This validation group is intended ONLY for procedures with all dependent sub-entities,
+    // like UiDefinition, FormDefinitions, etc.
+    public const VALIDATION_GROUP_MANDATORY_PROCEDURE_ALL_INCLUDED = 'mandatory_procedure_all_included';
+
+    public const VALIDATION_GROUP_DEFAULT = 'Default';
+
+    /**
+     * Key used in phases to determine state of participation.
+     *
+     * @var string
+     */
+    public const PARTICIPATIONSTATE_KEY = 'participationstate';
+
+    /**
+     * Value to define that participation has finished for procedure.
+     *
+     * @var string
+     */
+    public const PARTICIPATIONSTATE_FINISHED = 'finished';
+
+    /**
+     * Value to define that users may provide an access token to participate.
+     *
+     * @value string
+     */
+    public const PARTICIPATIONSTATE_PARTICIPATE_WITH_TOKEN = 'participateWithToken';
+
+    /**
+     * Value to define the public participation phase in a Procedure.
+     */
+    public const PROCEDURE_PARTICIPATION_PHASE = 'participation';
+
+    /**
+     * Possible values for procedure permissionsets.
+     */
+    public const PROCEDURE_PHASE_PERMISSIONSET_HIDDEN = 'hidden';
+    public const PROCEDURE_PHASE_PERMISSIONSET_READ = 'read';
+    public const PROCEDURE_PHASE_PERMISSIONSET_WRITE = 'write';
+
+    public const MAX_PUBLIC_PARTICIPATION_CONTACT_LENGTH = 2000;
+    public const MAX_PUBLIC_DESCRIPTION_LENGTH = 10000;
+
+    /**
+     * @return Collection<int,ElementsInterface>
+     */
+    public function getElements(): Collection;
+
+    /**
+     * @param ArrayCollection $elements
+     */
+    public function setElements($elements);
+
+    public function addElement(ElementsInterface $element): void;
+
+    /**
+     * @param string $id
+     *
+     * @return $this
+     */
+    public function setId($id);
+
+    /**
+     * Set pName.
+     *
+     * @param string $name
+     *
+     * @return ProcedureInterface
+     */
+    public function setName($name);
+
+    public function getName(): string;
+
+    /**
+     * Set oName.
+     *
+     * @param string $orgaName
+     *
+     * @return ProcedureInterface
+     */
+    public function setOrgaName($orgaName);
+
+    /**
+     * Get oName.
+     *
+     * @return string
+     */
+    public function getOrgaName();
+
+    /**
+     * @return string|null
+     */
+    public function getOrgaId();
+
+    public function getOrga(): ?OrgaInterface;
+
+    /**
+     * @param OrgaInterface $orga
+     *
+     * @return $this
+     */
+    public function setOrga($orga);
+
+    /**
+     * Set pDesc.
+     *
+     * @param string $desc
+     *
+     * @return ProcedureInterface
+     */
+    public function setDesc($desc);
+
+    /**
+     * Get pDesc.
+     *
+     * @return string
+     */
+    public function getDesc();
+
+    /**
+     * Set pPhase.
+     *
+     * @param string $phase
+     *
+     * @return ProcedureInterface
+     */
+    public function setPhase($phase);
+
+    public function getPhase(): string;
+
+    /**
+     * @return string
+     */
+    public function getPhaseName();
+
+    /**
+     * @param string $phaseName
+     */
+    public function setPhaseName($phaseName);
+
+    public function getPhasePermissionset(): string;
+
+    public function setPhasePermissionset(string $phasePermissionset): ProcedureInterface;
+
+    /**
+     * Set pStep.
+     *
+     * @param string $step
+     *
+     * @return ProcedureInterface
+     */
+    public function setStep($step);
+
+    /**
+     * Get pStep.
+     *
+     * @return string
+     */
+    public function getStep();
+
+    /**
+     * Set pLogo.
+     *
+     * @param string $logo
+     *
+     * @return ProcedureInterface
+     */
+    public function setLogo($logo);
+
+    /**
+     * Get pLogo.
+     *
+     * @return string
+     */
+    public function getLogo();
+
+    /**
+     * Set pExternId.
+     *
+     * @param string $externId
+     *
+     * @return ProcedureInterface
+     */
+    public function setExternId($externId);
+
+    /**
+     * Get pExternId.
+     *
+     * @return string
+     */
+    public function getExternId();
+
+    /**
+     * Set pPlisId.
+     *
+     * @param string $plisId
+     *
+     * @return ProcedureInterface
+     */
+    public function setPlisId($plisId);
+
+    /**
+     * Get pPlisId.
+     *
+     * @return string
+     */
+    public function getPlisId();
+
+    /**
+     * Set pClosed.
+     *
+     * @param bool $closed
+     *
+     * @return ProcedureInterface
+     */
+    public function setClosed($closed);
+
+    /**
+     * Get pClosed.
+     *
+     * @return bool
+     */
+    public function getClosed();
+
+    /**
+     * Set deleted.
+     *
+     * @param bool $deleted
+     *
+     * @return ProcedureInterface
+     */
+    public function setDeleted($deleted);
+
+    /**
+     * Get Deleted.
+     *
+     * @return bool
+     */
+    public function getDeleted();
+
+    /**
+     * Is Deleted.
+     *
+     * @return bool
+     */
+    public function isDeleted();
+
+    /**
+     * Tells Elasticsearch whether Entity should be indexed.
+     *
+     * @return bool
+     */
+    public function shouldBeIndexed();
+
+    /**
+     * Set pMaster.
+     *
+     * @param bool $master
+     *
+     * @return ProcedureInterface
+     */
+    public function setMaster($master);
+
+    /**
+     * Get pMaster.
+     *
+     * @return bool
+     */
+    public function getMaster();
+
+    public function setMasterTemplate(bool $masterTemplate): ProcedureInterface;
+
+    public function isMasterTemplate(): bool;
+
+    /**
+     * Set pExternalName.
+     *
+     * @param string $externalName
+     *
+     * @return ProcedureInterface
+     */
+    public function setExternalName($externalName);
+
+    /**
+     * Get pExternalName.
+     */
+    public function getExternalName(): string;
+
+    /**
+     * Set pExternalDesc.
+     *
+     * @param string $externalDesc
+     *
+     * @return ProcedureInterface
+     */
+    public function setExternalDesc($externalDesc);
+
+    /**
+     * Get pExternalDesc.
+     *
+     * @return string
+     */
+    public function getExternalDesc();
+
+    /**
+     * Set pPublicParticipation.
+     *
+     * @param bool $publicParticipation
+     *
+     * @return ProcedureInterface
+     */
+    public function setPublicParticipation($publicParticipation);
+
+    /**
+     * Get pPublicParticipation.
+     *
+     * @return bool
+     */
+    public function getPublicParticipation();
+
+    /**
+     * Set pPublicParticipationPhase.
+     *
+     * @param string $publicParticipationPhase
+     *
+     * @return ProcedureInterface
+     */
+    public function setPublicParticipationPhase($publicParticipationPhase);
+
+    public function getPublicParticipationPhase(): string;
+
+    /**
+     * @return string
+     */
+    public function getPublicParticipationPhaseName();
+
+    /**
+     * @param string $publicParticipationPhaseName
+     */
+    public function setPublicParticipationPhaseName($publicParticipationPhaseName);
+
+    public function getPublicParticipationPhasePermissionset(): string;
+
+    public function setPublicParticipationPhasePermissionset(string $publicParticipationPhasePermissionset): ProcedureInterface;
+
+    /**
+     * Set pPublicParticipationStep.
+     *
+     * @param string $publicParticipationStep
+     *
+     * @return ProcedureInterface
+     */
+    public function setPublicParticipationStep($publicParticipationStep);
+
+    /**
+     * Get pPublicParticipationStep.
+     *
+     * @return string
+     */
+    public function getPublicParticipationStep();
+
+    /**
+     * Set pPublicParticipationStart.
+     *
+     * @param DateTime $publicParticipationStartDate
+     *
+     * @return ProcedureInterface
+     */
+    public function setPublicParticipationStartDate($publicParticipationStartDate);
+
+    /**
+     * Get pPublicParticipationStart.
+     *
+     * @return DateTime
+     */
+    public function getPublicParticipationStartDate();
+
+    /**
+     * Get publicParticipationStartDate as Timestamp.
+     *
+     * @return int
+     */
+    public function getPublicParticipationStartDateTimestamp();
+
+    /**
+     * Set pPublicParticipationEnd.
+     *
+     * @param DateTime $publicParticipationEndDate
+     *
+     * @return ProcedureInterface
+     */
+    public function setPublicParticipationEndDate($publicParticipationEndDate);
+
+    /**
+     * Get pPublicParticipationEnd.
+     *
+     * @return DateTime
+     */
+    public function getPublicParticipationEndDate();
+
+    /**
+     * Get pPublicParticipationEnd as Timestamp.
+     *
+     * @return int
+     */
+    public function getPublicParticipationEndDateTimestamp();
+
+    /**
+     * Get publicParticipationPublicationEnabled.
+     *
+     * @return bool
+     */
+    public function getPublicParticipationPublicationEnabled();
+
+    /**
+     * Set publicParticipationPublicationEnabled.
+     *
+     * @param bool $enabled
+     *
+     * @return ProcedureInterface
+     */
+    public function setPublicParticipationPublicationEnabled($enabled);
+
+    /**
+     * Set pPublicParticipationContact.
+     *
+     * @param string $publicParticipationContact
+     *
+     * @return ProcedureInterface
+     */
+    public function setPublicParticipationContact($publicParticipationContact);
+
+    /**
+     * Get pPublicParticipationContact.
+     *
+     * @return string
+     */
+    public function getPublicParticipationContact();
+
+    /**
+     * Set pLocationName.
+     *
+     * @param string $locationName
+     *
+     * @return ProcedureInterface
+     */
+    public function setLocationName($locationName);
+
+    /**
+     * Get pLocationName.
+     *
+     * @return string
+     */
+    public function getLocationName();
+
+    /**
+     * Set pLocationPostCode.
+     *
+     * @param string $locationPostCode
+     *
+     * @return ProcedureInterface
+     */
+    public function setLocationPostCode($locationPostCode);
+
+    /**
+     * Get pLocationPostCode.
+     *
+     * @return string
+     */
+    public function getLocationPostCode();
+
+    /**
+     * @return string
+     */
+    public function getCoordinate();
+
+    /**
+     * Getter used to populate Elasticsearch.
+     */
+    public function isParticipationGuestOnly(): bool;
+
+    /**
+     * @return string
+     */
+    public function getPlanningArea();
+
+    /**
+     * Set pMunicipalCode.
+     *
+     * @param string $municipalCode
+     *
+     * @return ProcedureInterface
+     */
+    public function setMunicipalCode($municipalCode);
+
+    /**
+     * Get pMunicipalCode.
+     *
+     * @return string
+     */
+    public function getMunicipalCode();
+
+    public function getArs(): string;
+
+    public function setArs(string $ars): ProcedureInterface;
+
+    /**
+     * Set pCreatedDate.
+     *
+     * @param DateTime $createdDate
+     *
+     * @return ProcedureInterface
+     */
+    public function setCreatedDate($createdDate);
+
+    /**
+     * Get pCreatedDate.
+     *
+     * @return DateTime
+     */
+    public function getCreatedDate();
+
+    /**
+     * Set pStartDate.
+     *
+     * @param DateTime $startDate
+     *
+     * @return ProcedureInterface
+     */
+    public function setStartDate($startDate);
+
+    /**
+     * Get pStartDate.
+     *
+     * @return DateTime
+     */
+    public function getStartDate();
+
+    /**
+     * Get getStartDate as Timestamp.
+     *
+     * @return int
+     */
+    public function getStartDateTimestamp();
+
+    /**
+     * Set pEndDate.
+     *
+     * @param DateTime $endDate
+     *
+     * @return ProcedureInterface
+     */
+    public function setEndDate($endDate);
+
+    /**
+     * Get pEndDate.
+     *
+     * @return DateTime
+     */
+    public function getEndDate();
+
+    /**
+     * Get getEndDate as Timestamp.
+     *
+     * @return int
+     */
+    public function getEndDateTimestamp();
+
+    /**
+     * Set pClosedDate.
+     *
+     * @param DateTime $closedDate
+     *
+     * @return ProcedureInterface
+     */
+    public function setClosedDate($closedDate);
+
+    /**
+     * Get pClosedDate.
+     *
+     * @return DateTime
+     */
+    public function getClosedDate();
+
+    /**
+     * Set pDeletedDate.
+     *
+     * @param DateTime $deletedDate
+     *
+     * @return ProcedureInterface
+     */
+    public function setDeletedDate($deletedDate);
+
+    /**
+     * Get pDeletedDate.
+     *
+     * @return DateTime
+     */
+    public function getDeletedDate();
+
+    /**
+     * Set organisations like plannig agencies
+     * Does not contains the owning organisation.
+     *
+     * @param array $organisation
+     *
+     * @return ProcedureInterface
+     */
+    public function setOrganisation($organisation);
+
+    /**
+     * Add Organisation to this Procedure.
+     *
+     * @param OrgaInterface $organisation - Organisation to add
+     *
+     * @return ProcedureInterface - updated Procedure
+     */
+    public function addOrganisation(OrgaInterface $organisation);
+
+    /**
+     * Detach a Organisation from this Procedure.
+     *
+     * @return ProcedureInterface
+     */
+    public function removeOrganisation(OrgaInterface $organisation);
+
+    /**
+     * Get o.
+     *
+     * @return ArrayCollection
+     */
+    public function getOrganisation();
+
+    /**
+     * Warning: This method may lead to performance issues as every organisation is hydrated by
+     * doctrine.
+     * When possible use {@link ProcedureRepository::getInvitedOrgaIds()} instead which returns the same
+     * values.
+     *
+     * @return string[]
+     */
+    public function getOrganisationIds();
+
+    /**
+     * Is procedure added to Organisation.
+     *
+     * @param string $orgaId
+     *
+     * @return bool
+     */
+    public function hasOrganisation($orgaId);
+
+    public function getSettings(): ProcedureSettingsInterface;
+
+    public function setSettings(ProcedureSettingsInterface $settings): void;
+
+    /**
+     * Get all tags that are available in this procedure.
+     *
+     * @return ArrayCollection<int,TagInterface>
+     */
+    public function getTags(): ArrayCollection;
+
+    /**
+     * Get all topics that are available in this procedure.
+     *
+     * @return ArrayCollection
+     */
+    public function getTopics();
+
+    /**
+     * @return Collection<int, OrgaInterface>
+     */
+    public function getPlanningOffices(): Collection;
+
+    /**
+     * @param OrgaInterface[] $planningOffices
+     */
+    public function setPlanningOffices($planningOffices): self;
+
+    /**
+     * @return ArrayCollection[Orga]
+     */
+    public function getDataInputOrganisations();
+
+    /**
+     * Get dataInputOrgaIds as array.
+     *
+     * @return string[]
+     */
+    public function getDataInputOrgaIds();
+
+    /**
+     * @param OrgaInterface[] $dataInputOrganisations
+     *
+     * @return ProcedureInterface
+     */
+    public function setDataInputOrganisations($dataInputOrganisations);
+
+    public function getPictogram(): ?string;
+
+    /**
+     * @return Collection<int, NotificationReceiverInterface>
+     */
+    public function getNotificationReceivers(): Collection;
+
+    /**
+     * @param NotificationReceiverInterface[] $notificationReceivers
+     */
+    public function setNotificationReceivers(array $notificationReceivers): void;
+
+    /**
+     * T8427
+     * Allow additional restriction of access to this Procedure.
+     * CustomizedAuthorizedUsers.
+     *
+     * @return Collection<int, UserInterface>
+     */
+    public function getAuthorizedUsers(): Collection;
+
+    /**
+     * @param ArrayCollection|array $authorizedUsers
+     */
+    public function setAuthorizedUsers($authorizedUsers): self;
+
+    /**
+     * @return string[]
+     */
+    public function getAuthorizedUserNames();
+
+    /**
+     * @return string[]
+     */
+    public function getAuthorizedUserIds(): array;
+
+    /**
+     * Warning: This method may lead to performance issues as every organisation is hydrated by
+     * doctrine.
+     * When possible use {@link ProcedureRepository::getPlanningOfficeIds()} instead which returns the same
+     * values.
+     *
+     * Returns Ids of procedures' planning offices.
+     *
+     * @return string[]
+     */
+    public function getPlanningOfficesIds();
+
+    /**
+     * @return string
+     */
+    public function getLegalNotice();
+
+    /**
+     * @return string
+     */
+    public function getAgencyMainEmailAddress();
+
+    /**
+     * @param string $agencyMainEmailAddress
+     *
+     * @return $this
+     */
+    public function setAgencyMainEmailAddress($agencyMainEmailAddress);
+    /**
+     * @return Collection<int, EmailAddressInterface>
+     */
+    public function getAgencyExtraEmailAddresses();
+
+    /**
+     * @param Collection<int, EmailAddressInterface> $agencyExtraEmailAddresses
+     *
+     * @return $this
+     */
+    public function setAgencyExtraEmailAddresses(Collection $agencyExtraEmailAddresses): ProcedureInterface;
+
+    /**
+     * @param Collection<int, EmailAddressInterface> $agencyExtraEmailAddresses
+     *
+     * @return $this
+     */
+    public function addAgencyExtraEmailAddresses(Collection $agencyExtraEmailAddresses): ProcedureInterface;
+
+    /**
+     * Returns a blankspace separated list with the Orga Slugs (current slug plus the previous ones that the Orga might had).
+     *
+     * @return string
+     */
+    public function getOrgaSlugs();
+
+    /**
+     * Set pShortUrl.
+     *
+     * @param string $shortUrl
+     *
+     * @return ProcedureInterface
+     */
+    public function setShortUrl($shortUrl);
+
+    /**
+     * Get pShortUrl.
+     *
+     * @return string
+     */
+    public function getShortUrl();
+
+    public function getSubdomain(): string;
+
+    public function isCustomerMasterBlueprint(): bool;
+
+    /**
+     * @return CustomerInterface|null
+     */
+    public function getCustomer();
+
+    /**
+     * @return string|null
+     */
+    public function getCustomerId();
+
+    /**
+     * @param CustomerInterface|null $customer
+     * @param bool          $handleBothSites
+     */
+    public function setCustomer($customer, $handleBothSites = true): ProcedureInterface;
+
+    public function getProcedureCategories(): Collection;
+
+    public function setProcedureCategories(array $procedureCategories): void;
+
+    /**
+     * Add ProcedureCategory to this Procedure.
+     *
+     * @return ProcedureInterface - updated Procedure
+     */
+    public function addProcedureCategory(ProcedureCategoryInterface $procedureCategory): ProcedureInterface;
+
+    /**
+     * Is ProcedureCategory attached to Procedure.
+     */
+    public function hasProcedureCategory(ProcedureCategoryInterface $procedureCategory): bool;
+
+    /**
+     * Detach ProcedureCategory from this Procedure.
+     */
+    public function removeProcedureCategory(ProcedureCategoryInterface $procedureCategory): self;
+
+    /**
+     * Detach ProcedureCategories from this Procedure.
+     */
+    public function removeProcedureCategories(array $procedureCategories): self;
+
+    /**
+     * Used for Elasticsearch indexing.
+     *
+     * @return array
+     */
+    public function getProcedureCategoryNames();
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getStatements();
+
+    public function setStatements(ArrayCollection $statements): void;
+
+    public function getSurveys(): Collection;
+
+    /**
+     * Returns first Survey in the list.
+     *
+     * @param string $surveyId
+     *
+     * @return SurveyInterface
+     */
+    public function getSurvey($surveyId): ?SurveyInterface;
+
+    public function addSurvey(SurveyInterface $survey): void;
+
+    public function getFirstSurvey(): ?SurveyInterface;
+
+    public function getProcedureBehaviorDefinition(): ?ProcedureBehaviorDefinitionInterface;
+
+    public function getProcedureUiDefinition(): ?ProcedureUiDefinitionInterface;
+
+    public function getStatementFormDefinition(): ?StatementFormDefinitionInterface;
+
+    public function getProcedureType(): ?ProcedureTypeInterface;
+
+    public function setProcedureType(ProcedureTypeInterface $procedureType): void;
+
+    public function setProcedureBehaviorDefinition(ProcedureBehaviorDefinitionInterface $procedureBehaviorDefinition): void;
+
+    public function setProcedureUiDefinition(ProcedureUiDefinitionInterface $procedureUiDefinition): void;
+
+    public function setStatementFormDefinition(StatementFormDefinitionInterface $statementFormDefinition): void;
+
+    public function getDefaultExportFieldsConfiguration(): ExportFieldsConfigurationInterface;
+
+    /**
+     * @return Collection<int, ExportFieldsConfigurationInterface>
+     */
+    public function getExportFieldsConfigurations(): Collection;
+
+    public function clearExportFieldsConfiguration(): void;
+    public function addExportFieldsConfiguration(ExportFieldsConfigurationInterface $exportFieldsConfiguration): self;
+
+    public function isInPublicParticipationPhase(): bool;
+
+    public function addTagTopic(TagTopicInterface $tagTopic): void;
+
+    /**
+     * @return Collection<int, FileInterface>
+     */
+    public function getFiles();
+
+    public function setFiles(?ArrayCollection $files): void;
+
+    public function getXtaPlanId(): string;
+
+    public function setXtaPlanId(string $xtaPlanId): self;
+
+    /**
+     * @return Collection<int, PlaceInterface>
+     */
+    public function getSegmentPlaces(): Collection;
+
+    public function addSegmentPlace(PlaceInterface $place): void;
+
 
 }

--- a/src/Contracts/Entities/ProcedurePersonInterface.php
+++ b/src/Contracts/Entities/ProcedurePersonInterface.php
@@ -2,6 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use Doctrine\Common\Collections\Collection;
 interface ProcedurePersonInterface extends UuidEntityInterface
 {
     public function getProcedure(): ProcedureInterface;
@@ -29,4 +30,10 @@ interface ProcedurePersonInterface extends UuidEntityInterface
     public function setEmailAddress(?string $emailAddress): ProcedurePersonInterface;
 
     public function getEmailAddress(): ?string;
+
+    public function getSimilarForeignStatements(): Collection;
+
+    public function addSimilarForeignStatement(StatementInterface $similarForeignStatement): void;
+
+    public function removeSimilarForeignStatement(StatementInterface $similarForeignStatement): void;
 }

--- a/src/Contracts/Entities/ProcedurePersonInterface.php
+++ b/src/Contracts/Entities/ProcedurePersonInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface ProcedurePersonInterface extends UuidEntityInterface
+{
+    public function getProcedure(): ProcedureInterface;
+
+    public function getFullName(): ?string;
+
+    public function setFullName(?string $fullName): ProcedurePersonInterface;
+
+    public function getStreetName(): ?string;
+
+    public function setStreetName(?string $streetName): ProcedurePersonInterface;
+
+    public function getStreetNumber(): ?string;
+
+    public function setStreetNumber(?string $streetNumber): ProcedurePersonInterface;
+
+    public function getCity(): ?string;
+
+    public function setCity(?string $city): ProcedurePersonInterface;
+
+    public function getPostalCode(): ?string;
+
+    public function setPostalCode(?string $postalCode): ProcedurePersonInterface;
+
+    public function setEmailAddress(?string $emailAddress): ProcedurePersonInterface;
+
+    public function getEmailAddress(): ?string;
+}

--- a/src/Contracts/Entities/ProcedureSettingsInterface.php
+++ b/src/Contracts/Entities/ProcedureSettingsInterface.php
@@ -1,0 +1,512 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use League\Fractal\Resource\Collection;
+use DateTime;
+
+interface ProcedureSettingsInterface extends UuidEntityInterface
+{
+    /**
+     * Max length of the {@see mapHint} field.
+     *
+     * @var int
+     */
+    public const MAP_HINT_MAX_LENGTH = 2000;
+    /**
+     * Min length of the {@see mapHint} field.
+     *
+     * @var int
+     */
+    public const MAP_HINT_MIN_LENGTH = 50;
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="_ps_id", type="string", length=36, options={"fixed":true})
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="\demosplan\DemosPlanCoreBundle\Doctrine\Generator\UuidV4Generator")
+     */
+
+    /**
+     * @param string $id
+     *
+     * @return $this
+     */
+    public function setId($id);
+
+    /**
+     * Set psMapExtent.
+     *
+     * @param string $mapExtent
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setMapExtent($mapExtent);
+
+    /**
+     * Get psMapExtent.
+     *
+     * @return string
+     */
+    public function getMapExtent();
+
+    /**
+     * Set psStartScale.
+     *
+     * @param string $startScale
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setStartScale($startScale);
+
+    /**
+     * Get psStartScale.
+     *
+     * @return string
+     */
+    public function getStartScale();
+
+    /**
+     * Set psAvailableScale.
+     *
+     * @param string $availableScale
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setAvailableScale($availableScale);
+
+    /**
+     * Get psAvailableScale.
+     *
+     * @return string
+     */
+    public function getAvailableScale();
+
+    /**
+     * Set psBoundingBox.
+     *
+     * @param string $boundingBox
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setBoundingBox($boundingBox);
+
+    /**
+     * Get psBoundingBox.
+     *
+     * @return string
+     */
+    public function getBoundingBox();
+
+    /**
+     * Set psInformationUrl.
+     *
+     * @param string $informationUrl
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setInformationUrl($informationUrl);
+
+    /**
+     * Get psInformationUrl.
+     *
+     * @return string
+     */
+    public function getInformationUrl();
+
+    /**
+     * Set psDefaultLayer.
+     *
+     * @param string $defaultLayer
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setDefaultLayer($defaultLayer);
+
+    /**
+     * Get psDefaultLayer.
+     *
+     * @return string
+     */
+    public function getDefaultLayer();
+
+    /**
+     * Set psTerritory.
+     *
+     * @param string $territory
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setTerritory($territory);
+
+    /**
+     * Get psTerritory.
+     *
+     * @return string
+     */
+    public function getTerritory();
+
+    /**
+     * Set psCoordinate.
+     *
+     * @param string $coordinate
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setCoordinate($coordinate);
+
+    /**
+     * Get psCoordinate.
+     *
+     * @return string
+     */
+    public function getCoordinate();
+
+    /**
+     * Set psPlanEnable.
+     *
+     * @param bool $planEnable
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setPlanEnable($planEnable);
+
+    /**
+     * Get psPlanEnable.
+     *
+     * @return bool
+     */
+    public function getPlanEnable();
+
+    /**
+     * Set psPlanText.
+     *
+     * @param string $planText
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setPlanText($planText);
+
+    /**
+     * Get psPlanText.
+     *
+     * @return string
+     */
+    public function getPlanText();
+
+    /**
+     * Set psPlanPdf.
+     *
+     * @param string $planPDF
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setPlanPDF($planPDF);
+
+    /**
+     * Get psPlanPdf.
+     *
+     * @return string
+     */
+    public function getPlanPDF();
+
+    /**
+     * Set psPlanPara1Pdf.
+     *
+     * @param string $planPara1PDF
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setPlanPara1PDF($planPara1PDF);
+
+    /**
+     * Get psPlanPara1Pdf.
+     *
+     * @return string
+     */
+    public function getPlanPara1PDF();
+
+    /**
+     * Set psPlanPara2Pdf.
+     *
+     * @param string $planPara2PDF
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setPlanPara2PDF($planPara2PDF);
+
+    /**
+     * Get psPlanPara2Pdf.
+     *
+     * @return string
+     */
+    public function getPlanPara2PDF();
+
+    /**
+     * Set psPlanDrawText.
+     *
+     * @param string $planDrawText
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setPlanDrawText($planDrawText);
+
+    /**
+     * Get psPlanDrawText.
+     *
+     * @return string
+     */
+    public function getPlanDrawText();
+
+    /**
+     * Set psPlanDrawPdf.
+     *
+     * @param string $planDrawPDF
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setPlanDrawPDF($planDrawPDF);
+
+    /**
+     * Get psPlanDrawPdf.
+     *
+     * @return string
+     */
+    public function getPlanDrawPDF();
+
+    /**
+     * Set psEmailTitle.
+     *
+     * @param string $emailTitle
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setEmailTitle($emailTitle);
+
+    /**
+     * Get psEmailTitle.
+     *
+     * @return string
+     */
+    public function getEmailTitle();
+
+    /**
+     * Set psEmailText.
+     *
+     * @param string $emailText
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setEmailText($emailText);
+
+    /**
+     * Get psEmailText.
+     *
+     * @return string
+     */
+    public function getEmailText();
+    /**
+     * Set psEmailCc.
+     *
+     * @param string $emailCc
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setEmailCc($emailCc);
+
+    /**
+     * Get psEmailCc.
+     *
+     * @return string
+     */
+    public function getEmailCc();
+
+    /**
+     * Set Links.
+     *
+     * @param string $links
+     *
+     * @return ProcedureInterface
+     */
+    public function setLinks($links);
+
+    /**
+     * Get Links.
+     *
+     * @return string
+     */
+    public function getLinks();
+
+    /**
+     * Set p.
+     *
+     * @param ProcedureInterface $procedure
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setProcedure(ProcedureInterface $procedure = null);
+
+    /**
+     * Get p.
+     *
+     * @return ProcedureInterface
+     */
+    public function getProcedure();
+
+    /**
+     * @param string $pictogram
+     *
+     * @return $this
+     */
+    public function setPictogram($pictogram);
+
+    public function getPictogram(): ?string;
+
+    /**
+     * Returns the internal phase to which will be switch, when the time(dateOfSwitchPhase) has come.
+     *
+     * @return string
+     */
+    public function getDesignatedPhase();
+
+    /**
+     * @param string $designatedPhase
+     *
+     * @return $this
+     */
+    public function setDesignatedPhase($designatedPhase);
+
+    /**
+     * Returns the external phase to which will be switch, when the time(dateOfSwitchPublicPhase) has come.
+     *
+     * @return string
+     */
+    public function getDesignatedPublicPhase();
+
+    /**
+     * @param string $designatedPublicPhase
+     *
+     * @return mixed
+     */
+    public function setDesignatedPublicPhase($designatedPublicPhase);
+
+    /**
+     * Returns the date which is defined for switching the current phase of the procedure to the designated phase.
+     * Null is a valid value in this case and indicates that no date is set.
+     *
+     * @return DateTime|null date, which is set | null if date not set or there are no related settings
+     */
+    public function getDesignatedSwitchDate(): ?DateTime;
+
+    public function setDesignatedSwitchDate(?DateTime $designatedSwitchDate): self;
+
+    /**
+     * Returns the date which is defined for switching the current public phase of the procedure to the designated phase.
+     * Null is a valid value in this case and indicates that no date is set.
+     *
+     * @return DateTime|null date, which is set | null if date not set or there are no related settings
+     */
+    public function getDesignatedPublicSwitchDate(): ?DateTime;
+
+    public function setDesignatedPublicSwitchDate(?DateTime $designatedPublicSwitchDate): self;
+
+    /**
+     * Returns the End Date to which will be switch, when the time(dateOfSwitchPhase) has come.
+     */
+    public function getDesignatedEndDate(): ?DateTime;
+
+    /**
+     * @param DateTime $designatedEndDate
+     *
+     * @return $this
+     */
+    public function setDesignatedEndDate($designatedEndDate);
+
+    /**
+     * Returns the End Date to which will be switch, when the time(dateOfSwitchPhase) has come.
+     */
+    public function getDesignatedPublicEndDate(): ?DateTime;
+
+    /**
+     * @param mixed $designatedPublicEndDate
+     *
+     * @return $this
+     */
+    public function setDesignatedPublicEndDate($designatedPublicEndDate);
+
+    /**
+     * Get sendMailsToCounties.
+     *
+     * @return bool
+     */
+    public function getSendMailsToCounties();
+
+    /**
+     * Set sendMailsToCounties.
+     *
+     * @param bool $sendMailsToCounties
+     */
+    public function setSendMailsToCounties($sendMailsToCounties);
+
+    public function getPlanningArea(): ?string;
+
+    /**
+     * @param string $planningArea
+     *
+     * @return ProcedureSettingsInterface
+     */
+    public function setPlanningArea($planningArea);
+
+    /**
+     * @return array
+     */
+    public function getScales();
+
+    /**
+     * @param array|string $scales
+     */
+    public function setScales($scales);
+
+    /**
+     * @return string
+     */
+    public function getLegalNotice();
+
+    /**
+     * @param string $legalNotice
+     */
+    public function setLegalNotice($legalNotice);
+
+    /**
+     * @return string
+     */
+    public function getCopyright();
+
+    /**
+     * @param string $copyright
+     */
+    public function setCopyright($copyright);
+
+    public function getMapHint(): string;
+
+    public function setMapHint(string $mapHint);
+
+    /**
+     * @return Collection<int,ProcedureInterface>
+     */
+    public function getAllowedSegmentAccessProcedures(): Collection;
+
+    /**
+     * @param Collection<int,ProcedureInterface> $allowedSegmentAccessProcedures
+     */
+    public function setAllowedSegmentAccessProcedures(Collection $allowedSegmentAccessProcedures): self;
+
+    public function getDesignatedPhaseChangeUser(): ?UserInterface;
+
+    public function getDesignatedPublicPhaseChangeUser(): ?UserInterface;
+
+    public function setDesignatedPhaseChangeUser(?UserInterface $designatedPhaseChangeUser): self;
+
+    public function setDesignatedPublicPhaseChangeUser(?UserInterface $designatedPublicPhaseChangeUser): self;
+}

--- a/src/Contracts/Entities/ProcedureSettingsInterface.php
+++ b/src/Contracts/Entities/ProcedureSettingsInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use Doctrine\Common\Collections\Collection;
 use DateTime;
 
-interface ProcedureSettingsInterface extends UuidEntityInterface
+interface ProcedureSettingsInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * Max length of the {@see mapHint} field.
@@ -34,6 +34,11 @@ interface ProcedureSettingsInterface extends UuidEntityInterface
      * @return $this
      */
     public function setId($id);
+
+    /**
+     * @return string|null
+     */
+    public function getPId();
 
     /**
      * Set psMapExtent.

--- a/src/Contracts/Entities/ProcedureSettingsInterface.php
+++ b/src/Contracts/Entities/ProcedureSettingsInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\Collection;
 use DateTime;
 
 interface ProcedureSettingsInterface extends UuidEntityInterface

--- a/src/Contracts/Entities/ProcedureTypeInterface.php
+++ b/src/Contracts/Entities/ProcedureTypeInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface ProcedureTypeInterface extends UuidEntityInterface
+{
+    public const BAULEITPLANUNG = 'Bauleitplanung';
+
+    public function getName(): string;
+
+    public function setName(string $name): void;
+
+    public function addProcedure(ProcedureInterface $procedure): void;
+
+    public function getStatementFormDefinition(): StatementFormDefinitionInterface;
+
+    public function getProcedureBehaviorDefinition(): ProcedureBehaviorDefinitionInterface;
+
+    public function getProcedureUiDefinition(): ProcedureUiDefinitionInterface;
+
+    public function getDescription(): string;
+
+    public function setDescription(string $description): void;
+
+    public function getCreationDate(): DateTime;
+
+    public function getModificationDate(): DateTime;
+}

--- a/src/Contracts/Entities/ProcedureTypeInterface.php
+++ b/src/Contracts/Entities/ProcedureTypeInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface ProcedureTypeInterface extends UuidEntityInterface
+interface ProcedureTypeInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const BAULEITPLANUNG = 'Bauleitplanung';
 

--- a/src/Contracts/Entities/ProcedureUiDefinitionInterface.php
+++ b/src/Contracts/Entities/ProcedureUiDefinitionInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface ProcedureUiDefinitionInterface extends UuidEntityInterface
+interface ProcedureUiDefinitionInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * The placeholder that may be used in {@link ProcedureUiDefinitionInterface::$statementPublicSubmitConfirmationText}.

--- a/src/Contracts/Entities/ProcedureUiDefinitionInterface.php
+++ b/src/Contracts/Entities/ProcedureUiDefinitionInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface ProcedureUiDefinitionInterface extends UuidEntityInterface
+{
+    /**
+     * The placeholder that may be used in {@link ProcedureUiDefinitionInterface::$statementPublicSubmitConfirmationText}.
+     * Do not simply change the value of this constant without migrating the data in the database too.
+     */
+    public const STATEMENT_PUBLIC_SUBMIT_CONFIRMATION_TEXT_PLACEHOLDER = 'statementPublicSubmitConfirmationTextPlaceholder';
+
+    public function getProcedure(): ?ProcedureInterface;
+
+    public function setProcedure(ProcedureInterface $procedure): void;
+
+    public function getProcedureType(): ?ProcedureTypeInterface;
+
+    public function setProcedureType(ProcedureTypeInterface $procedureType): void;
+
+    public function getMapHintDefault(): string;
+
+    public function setMapHintDefault(string $mapHintDefault): void;
+
+    public function getStatementFormHintStatement(): string;
+
+    public function setStatementFormHintStatement(string $statementFormHintStatement): void;
+
+    public function getStatementFormHintPersonalData(): string;
+
+    public function setStatementFormHintPersonalData(string $statementFormHintPersonalData): void;
+
+    public function getStatementFormHintRecheck(): string;
+
+    public function setStatementFormHintRecheck(string $statementFormHintRecheck): void;
+
+    public function getCreationDate(): DateTime;
+
+    public function getModificationDate(): DateTime;
+
+    public function getStatementPublicSubmitConfirmationText(): string;
+
+    public function setStatementPublicSubmitConfirmationText(string $statementPublicSubmitConfirmationText): void;
+
+}

--- a/src/Contracts/Entities/RoleInterface.php
+++ b/src/Contracts/Entities/RoleInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface RoleInterface extends UuidEntityInterface
+interface RoleInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * Fachplaner-Masteruser GLAUTH Kommune.

--- a/src/Contracts/Entities/RoleInterface.php
+++ b/src/Contracts/Entities/RoleInterface.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface RoleInterface extends UuidEntityInterface
+{
+    /**
+     * Fachplaner-Masteruser GLAUTH Kommune.
+     *
+     * @const string
+     */
+    public const ORGANISATION_ADMINISTRATION = 'RMOPSM';
+
+    /**
+     * Fachplaner-Admin GLAUTH Kommune.
+     *
+     * @const string
+     */
+    public const PLANNING_AGENCY_ADMIN = 'RMOPSA';
+
+    /**
+     * Fachplaner-Planungsbüro GLAUTH Kommune.
+     *
+     * @const string
+     */
+    public const PRIVATE_PLANNING_AGENCY = 'RMOPPO';
+
+    /**
+     * Fachplaner-Fachbehörde GLAUTH Kommune.
+     *
+     * @const string
+     */
+    public const PLANNING_SUPPORTING_DEPARTMENT = 'RMOPFB';
+
+    /**
+     * Fachplaner-Sachbearbeiter GLAUTH Kommune.
+     *
+     * @const string
+     */
+    public const PLANNING_AGENCY_WORKER = 'RMOPSD';
+
+    /**
+     * Institutions-Koordination GPSORG.
+     *
+     * @const string
+     */
+    public const PUBLIC_AGENCY_COORDINATION = 'RPSOCO';
+
+    /**
+     * Institutions-Sachbearbeitung GPSORG.
+     *
+     * @const string
+     */
+    public const PUBLIC_AGENCY_WORKER = 'RPSODE';
+
+    /**
+     * Institutions-Verwaltung.
+     *
+     * @const string
+     */
+    public const PUBLIC_AGENCY_SUPPORT = 'RPSUPP';
+
+    /**
+     * Gast GGUEST Gast.
+     *
+     * @const string
+     */
+    public const GUEST = 'RGUEST';
+
+    /**
+     * Interessent GINTPA Interessent.
+     *
+     * @const string
+     */
+    public const PROSPECT = 'RINTPA';
+
+    /**
+     * Verfahrenssupport GTSUPP Verfahrenssupport.
+     *
+     * Can add new users and assign roles.
+     *
+     * @const string
+     */
+    public const PLATFORM_SUPPORT = 'RTSUPP';
+
+    /**
+     * MasterUser eines Mandanten.
+     * Mandanten-Administration.
+     *
+     * Can manage customer affairs.
+     *
+     * @const string
+     */
+    public const CUSTOMER_MASTER_USER = 'RCOMAU';
+
+    /**
+     * Redakteur Global News.
+     *
+     * @const string
+     */
+    public const CONTENT_EDITOR = 'RTEDIT';
+
+    /**
+     * Bürger.
+     *
+     * @const string
+     */
+    public const CITIZEN = 'RCITIZ';
+
+    /**
+     * Moderator.
+     *
+     * @const string
+     */
+    public const BOARD_MODERATOR = 'RMODER';
+
+    /**
+     * Fachliche Leitstelle.
+     *
+     * @const string
+     */
+    public const PROCEDURE_CONTROL_UNIT = 'RFALST';
+
+    /**
+     * Datenerfassung.
+     *
+     * @const string
+     */
+    public const PROCEDURE_DATA_INPUT = 'RDATA';
+
+    /**
+     * Role for AiApiUser.
+     *
+     * @const string
+     */
+    public const API_AI_COMMUNICATOR = 'RAICOM';
+
+    // @improve T14690 move this to a better place. these are group codes, not role codes
+
+    /**
+     * Institution.
+     *
+     * @const string
+     */
+    public const GPSORG = 'GPSORG';
+
+    /**
+     * Gast/Bürger (unangemeldet).
+     *
+     * @const string
+     */
+    public const GGUEST = 'GGUEST';
+
+    /**
+     * Fachplaner.
+     *
+     * @const string
+     */
+    public const GLAUTH = 'GLAUTH';
+
+    /**
+     * Verfahrenssupport.
+     *
+     * @const string
+     */
+    public const GTSUPP = 'GTSUPP';
+
+    /**
+     * Moderatorengruppe.
+     *
+     * @const string
+     */
+    public const GMODER = 'GMODER';
+
+    /**
+     * Bürgergruppe (angemeldet).
+     *
+     * @const string
+     */
+    public const GCITIZ = 'GCITIZ';
+
+    /**
+     * Interessentengruppe.
+     *
+     * @const string
+     */
+    public const GINTPA = 'GINTPA';
+
+    /**
+     * Redakteurgruppe.
+     *
+     * @const string
+     */
+    public const GTEDIT = 'GTEDIT';
+
+    /**
+     * Fachliche Leitstelle Gruppe.
+     *
+     * @const string
+     */
+    public const GFALST = 'GFALST';
+
+    /**
+     * Datenerfassungsgruppe.
+     *
+     * @const string
+     */
+    public const GDATA = 'GDATA';
+
+    /**
+     * Institutions-Verwaltung Gruppe.
+     *
+     * @const string
+     */
+    public const GPSUPP = 'GPSUPP';
+
+    /**
+     * MasterUser Gruppe eines Mandanten.
+     *
+     * @const string
+     */
+    public const CUSTOMERMASTERUSERGROUP = 'GCOMAU';
+
+    /**
+     * Super fancy group name for Ai Communcation user.
+     *
+     * @const string
+     */
+    public const GAICOM = 'GAICOM';
+
+    /**
+     * AHB-Admin = Anhörungsbehörde-Admin = hearing authority admin.
+     * Administrator within an hearing authority (german: "Anhörungsbehörde").
+     *
+     * @const string
+     */
+    public const HEARING_AUTHORITY_ADMIN = 'RMOPHA';
+
+    /**
+     * AHB-SB = Anhörungsbehörde-Sachbearbeiter = hearing authority wroker.
+     *
+     * @const string
+     */
+    public const HEARING_AUTHORITY_WORKER = 'RMOHAW';
+
+    /**
+     * Group of hearing authority.
+     *
+     * @const string
+     */
+    public const GHEAUT = 'GHEAUT';
+
+    /**
+     * Mapping of the role codes to translation keys.
+     * This allows us to make them translatable.
+     *
+     * @const array<string, string>
+     */
+    public const ROLE_CODE_NAME_MAP =
+        [
+            self::ORGANISATION_ADMINISTRATION     => 'role.fpmu',
+            self::PRIVATE_PLANNING_AGENCY         => 'role.fppb',
+            self::PLANNING_AGENCY_ADMIN           => 'role.fpa',
+            self::PLANNING_SUPPORTING_DEPARTMENT  => 'role.fpfb',
+            self::PLANNING_AGENCY_WORKER          => 'role.fpsb',
+            self::PUBLIC_AGENCY_COORDINATION      => 'role.tbko',
+            self::PUBLIC_AGENCY_WORKER            => 'role.tbsb',
+            self::PUBLIC_AGENCY_SUPPORT           => 'role.tbmaster',
+            self::GUEST                           => 'role.guest',
+            self::PROSPECT                        => 'role.prospect',
+            self::PLATFORM_SUPPORT                => 'role.supp',
+            self::CUSTOMER_MASTER_USER            => 'role.cmu',
+            self::CONTENT_EDITOR                  => 'role.editor',
+            self::CITIZEN                         => 'role.citizen',
+            self::BOARD_MODERATOR                 => 'role.moder',
+            self::PROCEDURE_CONTROL_UNIT          => 'role.falst',
+            self::PROCEDURE_DATA_INPUT            => 'role.data',
+            self::API_AI_COMMUNICATOR             => 'role.aiapi',
+            self::HEARING_AUTHORITY_ADMIN         => 'role.haa',
+            self::HEARING_AUTHORITY_WORKER        => 'role.haw',
+        ];
+
+    /**
+     * Set code.
+     *
+     * @param string $code
+     *
+     * @return RoleInterface
+     */
+    public function setCode($code);
+
+    /**
+     * Get code.
+     *
+     * @return string
+     */
+    public function getCode();
+
+    /**
+     * Set Name.
+     *
+     * @param string $name
+     *
+     * @return RoleInterface
+     */
+    public function setName($name);
+
+    /**
+     * Get Name.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Set GroupCode.
+     *
+     * @param string $groupCode
+     *
+     * @return RoleInterface
+     */
+    public function setGroupCode($groupCode);
+
+    /**
+     * Get GroupCode.
+     *
+     * @return string
+     */
+    public function getGroupCode();
+
+    /**
+     * Set GroupName.
+     *
+     * @param string $groupName
+     *
+     * @return RoleInterface
+     */
+    public function setGroupName($groupName);
+
+    /**
+     * Get groupName.
+     *
+     * @return string
+     */
+    public function getGroupName();
+}

--- a/src/Contracts/Entities/SegmentCommentInterface.php
+++ b/src/Contracts/Entities/SegmentCommentInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface SegmentCommentInterface extends UuidEntityInterface
+{
+    public function getSubmitter(): ?UserInterface;
+
+    public function getPlace(): ?PlaceInterface;
+
+    public function getCreationDate(): DateTime;
+
+    public function getText(): string;
+}

--- a/src/Contracts/Entities/SegmentInterface.php
+++ b/src/Contracts/Entities/SegmentInterface.php
@@ -4,7 +4,37 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface SegmentInterface
+interface SegmentInterface extends StatementInterface
 {
+    public const VALIDATION_GROUP_SEGMENT_MANDATORY = 'segment_mandatory';
+
+    public const VALIDATION_GROUP_DEFAULT = 'segment_default';
+
+    public const VALIDATION_GROUP_IMPORT = 'segment_import';
+
+    public const RECOMMENDATION_FIELD_NAME = 'recommendation';
+
+    public function getParentStatementOfSegment(): StatementInterface;
+
+    public function getParentStatement(): StatementInterface;
+
+    public function setParentStatementOfSegment(StatementInterface $parentStatementOfSegment): void;
+
+    public function isSegment(): bool;
+
+    public function getOrderInProcedure(): int;
+
+    public function setOrderInProcedure(int $orderInProcedure): void;
+
+    public function setPlace(PlaceInterface $place): self;
+
+    public function getPlace(): PlaceInterface;
+
+    /**
+     * Needed for elasticsearch indexing.
+     */
+    public function getPlaceId(): string;
+
+    public function addComment(SegmentCommentInterface $comment): self;
 
 }

--- a/src/Contracts/Entities/SingleDocumentInterface.php
+++ b/src/Contracts/Entities/SingleDocumentInterface.php
@@ -2,7 +2,141 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface SingleDocumentInterface extends UuidEntityInterface
-{
+use League\Fractal\Resource\Collection;
+use DateTime;
 
+interface SingleDocumentInterface
+{
+    public const IMPORT_CREATION = 'importCreation';
+
+    /**
+     * Set procedure.
+     */
+    public function setProcedure(ProcedureInterface $procedure): self;
+
+    /**
+     * Get procedure.
+     */
+    public function getProcedure(): ProcedureInterface;
+
+    /**
+     * Get pId.
+     *
+     * @return string
+     */
+    public function getPId();
+
+    /**
+     * Get elementId.
+     *
+     * @return string
+     */
+    public function getElementId();
+
+    public function getElement(): ElementsInterface;
+
+    public function setElement(ElementsInterface $element): void;
+
+    /**
+     * Set eCategory.
+     */
+    public function setCategory(string $category): self;
+
+    /**
+     * Get eCategory.
+     */
+    public function getCategory(): string;
+
+    /**
+     * Set eTitle.
+     */
+    public function setTitle(string $title): self;
+
+    /**
+     * Get eTitle.
+     */
+    public function getTitle(): string;
+
+    /**
+     * Set eText.
+     */
+    public function setText(string $text): self;
+
+    /**
+     * Get eText.
+     */
+    public function getText(): string;
+
+    public function getSymbol(): string;
+
+    public function setSymbol(string $symbol): void;
+
+    public function getDocument(): string;
+
+    public function setDocument(string $document): void;
+
+    /**
+     * @return Collection<int, SingleDocumentVersionInterface>
+     */
+    public function getVersions(): Collection;
+
+    /**
+     * Set Order.
+     */
+    public function setOrder(int $order): self;
+
+    /**
+     * Get Order.
+     */
+    public function getOrder(): int;
+
+    public function isStatementEnabled(): bool;
+
+    public function setStatementEnabled(bool $statementEnabled): void;
+
+    /**
+     * Set eEnabled.
+     */
+    public function setVisible(bool $visible): self;
+
+    /**
+     * Get eEnabled.
+     */
+    public function getVisible(): bool;
+
+    /**
+     * Set eDeleted.
+     */
+    public function setDeleted(bool $deleted): self;
+
+    /**
+     * Get eDeleted.
+     */
+    public function getDeleted(): bool;
+
+    /**
+     * Set eCreateDate.
+     */
+    public function setCreateDate(DateTime $createDate): self;
+
+    public function getCreateDate(): DateTime;
+    /**
+     * Set eModifyDate.
+     */
+    public function setModifyDate(DateTime $modifyDate): self;
+
+    /**
+     * Get eModifyDate.
+     */
+    public function getModifyDate(): DateTime;
+
+    /**
+     * Set eDeleteDate.
+     */
+    public function setDeleteDate(DateTime $deleteDate): self;
+
+    /**
+     * Get eDeleteDate.
+     */
+    public function getDeleteDate(): DateTime;
 }

--- a/src/Contracts/Entities/SingleDocumentInterface.php
+++ b/src/Contracts/Entities/SingleDocumentInterface.php
@@ -5,9 +5,11 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use Doctrine\Common\Collections\Collection;
 use DateTime;
 
-interface SingleDocumentInterface
+interface SingleDocumentInterface extends CoreEntityInterface
 {
     public const IMPORT_CREATION = 'importCreation';
+
+    public function getId(): ?string;
 
     /**
      * Set procedure.

--- a/src/Contracts/Entities/SingleDocumentInterface.php
+++ b/src/Contracts/Entities/SingleDocumentInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\Collection;
 use DateTime;
 
 interface SingleDocumentInterface

--- a/src/Contracts/Entities/SingleDocumentVersionInterface.php
+++ b/src/Contracts/Entities/SingleDocumentVersionInterface.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface SingleDocumentVersionInterface extends UuidEntityInterface
+{
+    /**
+     * Set procedure.
+     *
+     * @param ProcedureInterface $procedure
+     */
+    public function setProcedure($procedure): self;
+
+    /**
+     * Get procedure.
+     *
+     * @return ProcedureInterface
+     */
+    public function getProcedure();
+
+    /**
+     * Get pId.
+     *
+     * @return string
+     */
+    public function getPId();
+
+    /**
+     * Get elementId.
+     *
+     * @return string
+     */
+    public function getElementId();
+
+    /**
+     * @return ElementsInterface|null
+     */
+    public function getElement();
+
+    /**
+     * @param ElementsInterface $element
+     */
+    public function setElement($element);
+
+    /**
+     * Set eCategory.
+     *
+     * @param string $category
+     */
+    public function setCategory($category): void;
+
+    /**
+     * Get eCategory.
+     *
+     * @return string
+     */
+    public function getCategory();
+
+    /**
+     * Set eTitle.
+     *
+     * @param string $title
+     */
+    public function setTitle($title): void;
+
+    /**
+     * Get eTitle.
+     */
+    public function getTitle(): string;
+
+    /**
+     * Set eText.
+     *
+     * @param string $text
+     */
+    public function setText($text): void;
+
+    /**
+     * Get eText.
+     *
+     * @return string
+     */
+    public function getText();
+
+    /**
+     * @return string
+     */
+    public function getSymbol();
+
+    /**
+     * @param string $symbol
+     */
+    public function setSymbol($symbol);
+
+    /**
+     * @return string
+     */
+    public function getDocument();
+
+    /**
+     * @param string $document
+     */
+    public function setDocument($document);
+
+    /**
+     * Set eOrder.
+     *
+     * @param int $order
+     */
+    public function setOrder($order): void;
+
+    /**
+     * Get eOrder.
+     *
+     * @return int
+     */
+    public function getOrder();
+
+    /**
+     * @return bool
+     */
+    public function isStatementEnabled();
+
+    /**
+     * @param bool $statementEnabled
+     */
+    public function setStatementEnabled($statementEnabled);
+
+    /**
+     * Set eEnabled.
+     */
+    public function setVisible(bool $visible): void;
+
+    /**
+     * Get eEnabled.
+     *
+     * @return bool
+     */
+    public function getVisible();
+
+    /**
+     * Set eDeleted.
+     *
+     * @param bool $deleted
+     */
+    public function setDeleted($deleted): void;
+
+    /**
+     * Get eDeleted.
+     *
+     * @return bool
+     */
+    public function getDeleted();
+
+    /**
+     * Set eCreateDate.
+     *
+     * @param DateTime $createDate
+     */
+    public function setCreateDate($createDate): void;
+
+    /**
+     * Get eCreateDate.
+     *
+     * @return DateTime
+     */
+    public function getCreateDate();
+
+    /**
+     * Set eModifyDate.
+     *
+     * @param DateTime $modifyDate
+     */
+    public function setModifyDate($modifyDate): void;
+
+    /**
+     * Get eModifyDate.
+     *
+     * @return DateTime
+     */
+    public function getModifyDate();
+
+    /**
+     * Set eDeleteDate.
+     *
+     * @param DateTime $deleteDate
+     */
+    public function setDeleteDate($deleteDate): void;
+
+    /**
+     * Get eDeleteDate.
+     *
+     * @return DateTime
+     */
+    public function getDeleteDate();
+
+    /**
+     * @return SingleDocumentInterface|null
+     */
+    public function getSingleDocument();
+
+    public function getSingleDocumentId();
+
+    /**
+     * @param SingleDocumentInterface $singleDocument
+     */
+    public function setSingleDocument($singleDocument);
+
+}

--- a/src/Contracts/Entities/SingleDocumentVersionInterface.php
+++ b/src/Contracts/Entities/SingleDocumentVersionInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface SingleDocumentVersionInterface extends UuidEntityInterface
+interface SingleDocumentVersionInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * Set procedure.

--- a/src/Contracts/Entities/SlugInterface.php
+++ b/src/Contracts/Entities/SlugInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface SlugInterface extends UuidEntityInterface
+interface SlugInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function setId(string $id);
 

--- a/src/Contracts/Entities/SluggedEntityInterface.php
+++ b/src/Contracts/Entities/SluggedEntityInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use Doctrine\Common\Collections\Collection;
 use Exception;
 
-interface SluggedEntityInterface extends UuidEntityInterface
+interface SluggedEntityInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function getSlugs(): Collection;
 

--- a/src/Contracts/Entities/StatementAttachmentInterface.php
+++ b/src/Contracts/Entities/StatementAttachmentInterface.php
@@ -4,7 +4,36 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface StatementAttachmentInterface
+interface StatementAttachmentInterface extends UuidEntityInterface
 {
+    /**
+     * A file that originally resulted in the original statement being created. E.g. a PDF file
+     * send via email.
+     *
+     * @var string
+     */
+    public const SOURCE_STATEMENT = 'source_statement';
+    /**
+     * Attachments with this type can have any kind of content. We can only speculate that it
+     * may be legal documents from lawyers or reviewers, images or other files supporting the
+     * statement.
+     *
+     * @var string
+     */
+    public const GENERIC = 'generic';
+
+    public function getFile(): FileInterface;
+
+    public function setFile(FileInterface $file): void;
+
+    public function setId(string $id): void;
+
+    public function getType(): string;
+
+    public function setType(string $type): void;
+
+    public function getStatement(): StatementInterface;
+
+    public function setStatement(StatementInterface $statement): void;
 
 }

--- a/src/Contracts/Entities/StatementAttributeInterface.php
+++ b/src/Contracts/Entities/StatementAttributeInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface StatementAttributeInterface extends UuidEntityInterface
+{
+    /**
+     * @param string $id
+     *
+     * @return $this
+     */
+    public function setId($id);
+
+    /**
+     * @return StatementInterface
+     */
+    public function getStatement();
+
+    /**
+     * @param StatementInterface $statement
+     *
+     * @return $this
+     */
+    public function setStatement($statement);
+
+    /**
+     * @return DraftStatementInterface
+     */
+    public function getDraftStatement();
+
+    /**
+     * @param DraftStatementInterface $draftStatement
+     *
+     * @return $this
+     */
+    public function setDraftStatement($draftStatement);
+
+    /**
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * @param string $type
+     *
+     * @return $this
+     */
+    public function setType($type);
+
+    /**
+     * @return string
+     */
+    public function getValue();
+
+    /**
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setValue($value);
+
+}

--- a/src/Contracts/Entities/StatementAttributeInterface.php
+++ b/src/Contracts/Entities/StatementAttributeInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface StatementAttributeInterface extends UuidEntityInterface
+interface StatementAttributeInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @param string $id

--- a/src/Contracts/Entities/StatementFieldDefinitionInterface.php
+++ b/src/Contracts/Entities/StatementFieldDefinitionInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface StatementFieldDefinitionInterface extends UuidEntityInterface
+{
+    public function isEnabled(): bool;
+
+    public function setEnabled(bool $enabled): void;
+
+    public function getName(): string;
+
+    public function getId(): ?string;
+
+    public function getStatementFormDefinition(): StatementFormDefinitionInterface;
+
+    public function isRequired(): bool;
+
+    public function setRequired(bool $required): void;
+
+    public function getCreationDate(): DateTime;
+
+    public function getModificationDate(): DateTime;
+
+    public function getOrderNumber(): int;
+
+}

--- a/src/Contracts/Entities/StatementFieldDefinitionInterface.php
+++ b/src/Contracts/Entities/StatementFieldDefinitionInterface.php
@@ -4,15 +4,13 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface StatementFieldDefinitionInterface extends UuidEntityInterface
+interface StatementFieldDefinitionInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public function isEnabled(): bool;
 
     public function setEnabled(bool $enabled): void;
 
     public function getName(): string;
-
-    public function getId(): ?string;
 
     public function getStatementFormDefinition(): StatementFormDefinitionInterface;
 

--- a/src/Contracts/Entities/StatementFormDefinitionInterface.php
+++ b/src/Contracts/Entities/StatementFormDefinitionInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use League\Fractal\Resource\Collection;
+use DateTime;
+
+interface StatementFormDefinitionInterface extends UuidEntityInterface
+{
+    public const MAP_AND_COUNTY_REFERENCE = 'mapAndCountyReference';
+    public const COUNTY_REFERENCE = 'countyReference';
+    public const NAME = 'name';
+    public const POSTAL_AND_CITY = 'postalAndCity';
+    public const GET_EVALUATION_MAIL_VIA_EMAIL = 'getEvaluationMailViaEmail';
+    public const GET_EVALUATION_MAIL_VIA_SNAIL_MAIL_OR_EMAIL = 'getEvaluationMailViaSnailMailOrEmail';
+
+    public const CITIZEN_XOR_ORGA_AND_ORGA_NAME = 'citizenXorOrgaAndOrgaName';
+    public const STREET = 'street';
+    public const STREET_AND_HOUSE_NUMBER = 'streetAndHouseNumber';
+    public const PHONE = 'phoneNumber';
+    public const EMAIL = 'emailAddress';
+    public const PHONE_OR_EMAIL = 'phoneOrEmail';
+    public const STATE_AND_GROUP_AND_ORGA_NAME_AND_POSITION = 'stateAndGroupAndOrgaNameAndPosition';
+
+    public function getFieldDefinitions(): Collection;
+
+    /**
+     * @return Collection<int, StatementFieldDefinitionInterface>
+     */
+    public function getEnabledFieldDefinitions(): Collection;
+
+    public function getFieldDefinitionByName(string $name): ?StatementFieldDefinitionInterface;
+
+    public function isFieldDefinitionEnabled(string $name);
+
+    public function getId(): ?string;
+
+    public function getProcedure(): ?ProcedureInterface;
+
+    public function setProcedure(ProcedureInterface $procedure): void;
+
+    public function getProcedureType(): ?ProcedureTypeInterface;
+
+    public function setProcedureType(ProcedureTypeInterface $procedureType): void;
+
+    public function getCreationDate(): DateTime;
+
+    public function getModificationDate(): DateTime;
+}

--- a/src/Contracts/Entities/StatementFormDefinitionInterface.php
+++ b/src/Contracts/Entities/StatementFormDefinitionInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\Collection;
 use DateTime;
 
 interface StatementFormDefinitionInterface extends UuidEntityInterface

--- a/src/Contracts/Entities/StatementFormDefinitionInterface.php
+++ b/src/Contracts/Entities/StatementFormDefinitionInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use Doctrine\Common\Collections\Collection;
 use DateTime;
 
-interface StatementFormDefinitionInterface extends UuidEntityInterface
+interface StatementFormDefinitionInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const MAP_AND_COUNTY_REFERENCE = 'mapAndCountyReference';
     public const COUNTY_REFERENCE = 'countyReference';
@@ -32,9 +32,6 @@ interface StatementFormDefinitionInterface extends UuidEntityInterface
     public function getFieldDefinitionByName(string $name): ?StatementFieldDefinitionInterface;
 
     public function isFieldDefinitionEnabled(string $name);
-
-    public function getId(): ?string;
-
     public function getProcedure(): ?ProcedureInterface;
 
     public function setProcedure(ProcedureInterface $procedure): void;

--- a/src/Contracts/Entities/StatementFragmentInterface.php
+++ b/src/Contracts/Entities/StatementFragmentInterface.php
@@ -83,7 +83,7 @@ interface StatementFragmentInterface extends UuidEntityInterface
     public function getTagsAndTopicsAsString();
 
     public function getTagsAndTopics();
-    
+
     public function getTopics();
 
     /**

--- a/src/Contracts/Entities/StatementFragmentInterface.php
+++ b/src/Contracts/Entities/StatementFragmentInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use Doctrine\Common\Collections\ArrayCollection;
 use DateTime;
 
-interface StatementFragmentInterface extends UuidEntityInterface
+interface StatementFragmentInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const VALIDATION_GROUP_MANDATORY = 'mandatory';
 
@@ -147,8 +147,6 @@ interface StatementFragmentInterface extends UuidEntityInterface
      */
     public function getModified();
 
-    public function getId(): ?string;
-
     /**
      * Needed to create a StatementFragment from StatementFragmentDataObject.
      *
@@ -170,6 +168,11 @@ interface StatementFragmentInterface extends UuidEntityInterface
      * @return string|null
      */
     public function getVote();
+
+    /**
+     * @param string|null $vote
+     */
+    public function setVote($vote): self;
 
     /**
      * @param string|null $vote;

--- a/src/Contracts/Entities/StatementFragmentInterface.php
+++ b/src/Contracts/Entities/StatementFragmentInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\ArrayCollection;
 use DateTime;
 
 interface StatementFragmentInterface extends UuidEntityInterface

--- a/src/Contracts/Entities/StatementFragmentInterface.php
+++ b/src/Contracts/Entities/StatementFragmentInterface.php
@@ -1,0 +1,611 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use League\Fractal\Resource\ArrayCollection;
+use DateTime;
+
+interface StatementFragmentInterface extends UuidEntityInterface
+{
+    public const VALIDATION_GROUP_MANDATORY = 'mandatory';
+
+    /**
+     * @return StatementInterface
+     */
+    public function getStatement();
+
+    /**
+     * @param StatementInterface $statement
+     *
+     * @return StatementFragmentInterface
+     */
+    public function setStatement($statement);
+
+    /**
+     * Get statementId for easier use in Elasticsearch.
+     *
+     * @return string
+     */
+    public function getStatementId();
+
+    /**
+     * @return int
+     */
+    public function getDisplayIdRaw();
+
+    /**
+     * Pad DisplayId with 0, as Elasticsearch could not sort desc in the ancient version
+     * we have to use.
+     *
+     * @return string
+     */
+    public function getDisplayId();
+
+    /**
+     * @param int $displayId
+     */
+    public function setDisplayId($displayId);
+
+    /**
+     * @return string
+     */
+    public function getText();
+
+    /**
+     * @param string $text
+     *
+     * @return StatementFragmentInterface
+     */
+    public function setText($text);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getTags();
+
+    /**
+     * Note: Please search via string search to find usage of method.
+     *
+     * @return string[]
+     */
+    public function getTagIds();
+
+    /**
+     * Returns the names of all Tags assigned to this Statement.
+     *
+     * @return array()
+     */
+    public function getTagNames();
+
+    /**
+     * @return string
+     */
+    public function getTagsAndTopicsAsString();
+
+    public function getTagsAndTopics();
+    
+    public function getTopics();
+
+    /**
+     * @param ArrayCollection|array $tags
+     *
+     * @return StatementFragmentInterface
+     */
+    public function setTags($tags);
+
+    /**
+     * Adds a tag to this statement fragment.
+     *
+     * @param TagInterface $tag
+     */
+    public function addTag(TagInterface $tag);
+
+    /**
+     * Removes a tag to this statement fragment.
+     *
+     * @param TagInterface $tag
+     */
+    public function removeTag(TagInterface $tag);
+
+    /**
+     * Set procedure.
+     *
+     * @param ProcedureInterface $procedure
+     *
+     * @return StatementFragmentInterface
+     */
+    public function setProcedure($procedure);
+
+    /**
+     * Get procedure.
+     *
+     * @return ProcedureInterface
+     */
+    public function getProcedure();
+
+    /**
+     * Get procedureId for easier use in Elasticsearch.
+     *
+     * @return string
+     */
+    public function getProcedureId();
+
+    /**
+     * Get procedureName for easier use in Elasticsearch.
+     *
+     * @return string
+     */
+    public function getProcedureName();
+
+    /**
+     * @return DateTime
+     */
+    public function getCreated();
+
+    /**
+     * @return DateTime
+     */
+    public function getModified();
+
+    public function getId(): ?string;
+
+    /**
+     * Needed to create a StatementFragment from StatementFragmentDataObject.
+     *
+     * @param string $id
+     */
+    public function setId($id);
+
+    /**
+     * @return string|null
+     */
+    public function getVoteAdvice();
+
+    /**
+     * @param string|null $voteAdvice
+     */
+    public function setVoteAdvice($voteAdvice): self;
+
+    /**
+     * @return string|null
+     */
+    public function getVote();
+
+    /**
+     * @param string|null $vote;
+
+    /**
+     * @return DepartmentInterface
+     */
+    public function getDepartment();
+
+    /**
+     * @param DepartmentInterface|null $department
+     *
+     * @return $this
+     */
+    public function setDepartment($department);
+
+    /**
+     * Return DepartmentId for easier use in Elasticsearch.
+     *
+     * @return string|null
+     */
+    public function getDepartmentId();
+
+    /**
+     * @return string|null
+     */
+    public function getConsiderationAdvice();
+
+    /**
+     * @param string|null $considerationAdvice
+     */
+    public function setConsiderationAdvice($considerationAdvice): self;
+
+    /**
+     * @return string|null
+     */
+    public function getConsideration();
+
+    /**
+     * @param string|null $consideration
+     */
+    public function setConsideration($consideration): self;
+
+    public function addConsiderationParagraph(string $additionalConsiderationParagraphText);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getCounties();
+
+    /**
+     * Returns an array of ids.
+     * Note: Please search via string search to find usage of method.
+     *
+     * @return string[]
+     */
+    public function getCountyIds();
+
+    /**
+     * Returns an array of names.
+     *
+     * @return string[]
+     */
+    public function getCountyNames();
+
+    /**
+     * @param ArrayCollection|CountyInterface[] $counties
+     *
+     * @return $this
+     */
+    public function setCounties($counties);
+
+    /**
+     * Add County.
+     *
+     * @param CountyInterface $county
+     */
+    public function addCounty($county);
+
+    /**
+     * Remove County.
+     *
+     * @param CountyInterface $county
+     */
+    public function removeCounty($county);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getPriorityAreas();
+
+    /**
+     * Returns an array of ids.
+     * Note: Please search via string search to find usage of method.
+     *
+     * @return string[]
+     */
+    public function getPriorityAreaIds();
+
+    /**
+     * Returns an array of names.
+     *
+     * @return string[]
+     */
+    public function getPriorityAreaKeys();
+
+    /**
+     * @param ArrayCollection|PriorityAreaInterface[] $priorityAreas
+     *
+     * @return $this
+     */
+    public function setPriorityAreas($priorityAreas);
+
+    /**
+     * Add Priority Area.
+     */
+    public function addPriorityArea(PriorityAreaInterface $priorityArea);
+
+    /**
+     * Remove Priority Area.
+     */
+    public function removePriorityArea(PriorityAreaInterface $priorityArea);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getMunicipalities();
+
+    /**
+     * Returns an array of ids.
+     * Note: Please search via string search to find usage of method.
+     *
+     * @return string[]
+     */
+    public function getMunicipalityIds();
+
+    /**
+     * Returns an array of names.
+     *
+     * @return string[]
+     */
+    public function getMunicipalityNames();
+
+    /**
+     * @param ArrayCollection|MunicipalityInterface[] $municipalities
+     *
+     * @return $this
+     */
+    public function setMunicipalities($municipalities);
+
+    /**
+     * Add Municipality.
+     */
+    public function addMunicipality(MunicipalityInterface $municipality);
+
+    /**
+     * Remove Municipality.
+     */
+    public function removeMunicipality(MunicipalityInterface $municipality);
+
+    /**
+     * @return string|null
+     */
+    public function getArchivedOrgaName();
+
+    /**
+     * @param string|null $archivedOrgaName
+     */
+    public function setArchivedOrgaName($archivedOrgaName);
+
+    /**
+     * @return DepartmentInterface
+     */
+    public function getArchivedDepartment();
+
+    /**
+     * @param DepartmentInterface|null $archivedDepartment
+     */
+    public function setArchivedDepartment($archivedDepartment);
+
+    /**
+     * Return DepartmentId for easier use in Elasticsearch.
+     *
+     * @return string|null
+     */
+    public function getArchivedDepartmentId();
+
+    /**
+     * @return string|null
+     */
+    public function getArchivedDepartmentName();
+
+    /**
+     * @param string|null $archivedDepartmentName
+     */
+    public function setArchivedDepartmentName($archivedDepartmentName);
+
+    /**
+     * @return string|null
+     */
+    public function getArchivedVoteUserName();
+
+    /**
+     * @param string|null $archivedVoteUserName
+     */
+    public function setArchivedVoteUserName($archivedVoteUserName);
+
+    /**
+     * @return UserInterface
+     */
+    public function getAssignee();
+
+    /**
+     * @param UserInterface|null $assignee
+     */
+    public function setAssignee($assignee);
+
+    /**
+     * @return Collection<int,StatementFragmentVersionInterface>
+     */
+    public function getVersions();
+
+    /**
+     * @param Collection<StatementFragmentVersionInterface>|array $versions
+     */
+    public function setVersions($versions);
+
+    /**
+     * Will add a Version at the beginning of the array to ensure order by created 'desc'.
+     *
+     * @param StatementFragmentVersionInterface $version
+     */
+    public function addVersion($version);
+
+    /**
+     * @return UserInterface
+     */
+    public function getModifiedByUser();
+
+    /**
+     * @return string|null
+     */
+    public function getModifiedByUserId();
+
+    /**
+     * @param UserInterface $modifiedByUser
+     */
+    public function setModifiedByUser($modifiedByUser);
+
+    /**
+     * @return DepartmentInterface
+     */
+    public function getModifiedByDepartment();
+
+    /**
+     * @return string|null
+     */
+    public function getModifiedByDepartmentId();
+
+    /**
+     * @param DepartmentInterface $modifiedByDepartment
+     */
+    public function setModifiedByDepartment($modifiedByDepartment);
+
+    /**
+     * @return string
+     */
+    public function getStatus();
+
+    /**
+     * @param string $status
+     */
+    public function setStatus($status);
+
+    /**
+     * @see https://yaits.demos-deutschland.de/w/demosplan/functions/claim/ wiki: claiming
+     *
+     * @return UserInterface
+     */
+    public function getLastClaimed();
+
+    /**
+     * @param UserInterface $user
+     *
+     * @see https://yaits.demos-deutschland.de/w/demosplan/functions/claim/ wiki: claiming
+     */
+    public function setLastClaimed($user = null);
+
+    /**
+     * Virtual property for easier Elasticsearch handling.
+     *
+     * @return string|null
+     */
+    public function getLastClaimedUserId();
+
+    /**
+     * Get elementId.
+     *
+     * @return string
+     */
+    public function getElementId();
+
+    /**
+     * Get elementOrder.
+     *
+     * @return int
+     */
+    public function getElementOrder();
+
+    /**
+     * Get elementTitle.
+     *
+     * @return string
+     */
+    public function getElementTitle();
+
+    /**
+     * Get categoryType.
+     *
+     * Returns the category of the element that this statement refers to
+     *
+     * @return string
+     */
+    public function getElementCategory();
+
+    /**
+     * @return ElementsInterface|null
+     */
+    public function getElement();
+
+    /**
+     * @param ElementsInterface|null $element
+     */
+    public function setElement($element);
+
+    /**
+     * @return ParagraphVersionInterface|null
+     */
+    public function getParagraph();
+
+    /**
+     * @param ParagraphVersionInterface|null $paragraph
+     */
+    public function setParagraph($paragraph);
+
+    /**
+     * Get paragraphId.
+     *
+     * @return string
+     */
+    public function getParagraphId();
+
+    /**
+     * Get paragraphTitle.
+     *
+     * @return string
+     */
+    public function getParagraphTitle();
+
+    /**
+     * Get paragraphOrder.
+     *
+     * @return string
+     */
+    public function getParagraphOrder();
+
+    /**
+     * Get paragraphParentId.
+     *
+     * @return string
+     */
+    public function getParagraphParentId();
+
+    /**
+     * @return string|null returns the title of the parent paragraph (the paragraph of the paragraph version)
+     */
+    public function getParagraphParentTitle();
+
+    /**
+     * @return SingleDocumentVersionInterface
+     */
+    public function getDocument();
+    /**
+     * @param SingleDocumentVersionInterface $document
+     */
+    public function setDocument($document);
+
+    /**
+     * @return DateTime
+     */
+    public function getAssignedToFbDate();
+
+    /**
+     * @param DateTime $assignedToFbDate
+     */
+    public function setAssignedToFbDate($assignedToFbDate);
+
+    /**
+     * Tells Elasticsearch whether Entity should be indexed.
+     *
+     * @return bool
+     */
+    public function shouldBeIndexed();
+
+    /**
+     * Needed to create a grouped structure for an export in createElementsGroupStructure2().
+     * This method allows to create a group structure with paragraphs and documents on the same level.
+     */
+    public function getParagraphParentIdOrDocumentParentId(): ?string;
+
+    /**
+     * Needed to create a grouped structure for an export in createElementsGroupStructure2().
+     * This method allows to create a group structure with paragraphs and documents on the same level.
+     */
+    public function getParagraphParentTitleOrDocumentParentTitle(): ?string;
+
+    /**
+     * Get documentParentId.
+     *
+     * @return string
+     */
+    public function getDocumentParentId();
+
+    // @improve T13720
+
+    /**
+     * @return string|null
+     */
+    public function getDocumentParentTitle();
+
+    public function setCreated(DateTime $created);
+
+    public function setModified(DateTime $modified);
+
+    public function getSortIndex(): int;
+
+    public function setSortIndex(int $sortIndex): void;
+
+}

--- a/src/Contracts/Entities/StatementFragmentVersionInterface.php
+++ b/src/Contracts/Entities/StatementFragmentVersionInterface.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface StatementFragmentVersionInterface extends UuidEntityInterface
+{
+    /**
+     * @return StatementFragmentInterface
+     */
+    public function getStatementFragment();
+
+    /**
+     * @return $this
+     */
+    public function setStatementFragment(StatementFragmentInterface $relatedFragment);
+
+    /**
+     * @return int
+     */
+    public function getDisplayId();
+
+    /**
+     * @return string
+     */
+    public function getText();
+
+    /**
+     * @return string
+     */
+    public function getTagAndTopicNames();
+
+    /**
+     * @return ProcedureInterface
+     */
+    public function getProcedure();
+
+    /**
+     * @return string
+     */
+    public function getVoteAdvice();
+
+    /**
+     * @return string
+     */
+    public function getVote();
+
+    /**
+     * @return DateTime
+     */
+    public function getCreated();
+
+    /**
+     * @return string
+     */
+    public function getDepartmentName();
+
+    /**
+     * @return string
+     */
+    public function getConsiderationAdvice();
+
+    /**
+     * @return string
+     */
+    public function getConsideration();
+
+    /**
+     * @return string
+     */
+    public function getCountyNamesAsJson();
+
+    /**
+     * @return string
+     */
+    public function getPriorityAreaKeysAsJson();
+
+    /**
+     * @return string
+     */
+    public function getPriorityAreaNamesAsJson();
+
+    /**
+     * @return string
+     */
+    public function getMunicipalityNamesAsJson();
+
+    /**
+     * @return string
+     */
+    public function getArchivedOrgaName();
+
+    /**
+     * @return string
+     */
+    public function getArchivedDepartmentName();
+
+    /**
+     * @return string
+     */
+    public function getArchivedVoteUserName();
+
+    /**
+     * @param string $archivedVoteUserName
+     */
+    public function setArchivedVoteUserName($archivedVoteUserName);
+
+    /**
+     * @return string
+     */
+    public function getOrgaName();
+
+    /**
+     * @param string $orgaName
+     *
+     * @return $this
+     */
+    public function setOrgaName($orgaName);
+
+    /**
+     * @param int $displayId
+     */
+    public function setDisplayId($displayId);
+
+    /**
+     * @param string $text
+     */
+    public function setText($text);
+
+    /**
+     * @param string $tagAndTopicNames
+     */
+    public function setTagAndTopicNames($tagAndTopicNames);
+
+    /**
+     * @param ProcedureInterface $procedure
+     */
+    public function setProcedure($procedure);
+
+    /**
+     * @param string $voteAdvice
+     */
+    public function setVoteAdvice($voteAdvice);
+
+    /**
+     * @param string $vote
+     */
+    public function setVote($vote);
+
+    /**
+     * @param DateTime $created
+     */
+    public function setCreated($created);
+
+    /**
+     * @param string $departmentName
+     */
+    public function setDepartmentName($departmentName);
+
+    /**
+     * @param string $considerationAdvice
+     */
+    public function setConsiderationAdvice($considerationAdvice);
+
+    /**
+     * @param string $consideration
+     */
+    public function setConsideration($consideration);
+
+    /**
+     * @param string $archivedOrgaName
+     */
+    public function setArchivedOrgaName($archivedOrgaName);
+
+    /**
+     * @param string $archivedDepartmentName
+     */
+    public function setArchivedDepartmentName($archivedDepartmentName);
+
+    /**
+     * @return UserInterface
+     */
+    public function getModifiedByUser();
+
+    /**
+     * @return string|null
+     */
+    public function getModifiedByUserId();
+
+    /**
+     * @param UserInterface $modifiedByUser
+     */
+    public function setModifiedByUser($modifiedByUser);
+
+    /**
+     * @return DepartmentInterface
+     */
+    public function getModifiedByDepartment();
+
+    /**
+     * @return string|null
+     */
+    public function getModifiedByDepartmentId();
+
+    /**
+     * @param DepartmentInterface $modifiedByDepartment
+     */
+    public function setModifiedByDepartment($modifiedByDepartment);
+
+    /**
+     * Get elementTitle.
+     *
+     * @return string
+     */
+    public function getElementTitle();
+
+    /**
+     * @return string
+     */
+    public function getElementCategory();
+
+    /**
+     * @return ParagraphVersionInterface|null
+     */
+    public function getParagraph();
+
+    /**
+     * Get paragraphTitle.
+     *
+     * @return string
+     */
+    public function getParagraphTitle();
+
+    /**
+     * @return SingleDocumentVersionInterface
+     */
+    public function getDocument();
+
+    /**
+     * @param SingleDocumentVersionInterface $document
+     */
+    public function setDocument($document);
+
+    /**
+     * Get documentParentId.
+     *
+     * @return string
+     */
+    public function getDocumentParentId();
+
+}

--- a/src/Contracts/Entities/StatementFragmentVersionInterface.php
+++ b/src/Contracts/Entities/StatementFragmentVersionInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface StatementFragmentVersionInterface extends UuidEntityInterface
+interface StatementFragmentVersionInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @return StatementFragmentInterface

--- a/src/Contracts/Entities/StatementInterface.php
+++ b/src/Contracts/Entities/StatementInterface.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Exception;
 
-interface StatementInterface extends UuidEntityInterface, SegmentInterface
+interface StatementInterface extends UuidEntityInterface
 {
     public const IMPORT_VALIDATION = 'import';
     public const DEFAULT_VALIDATION = 'Default';

--- a/src/Contracts/Entities/StatementInterface.php
+++ b/src/Contracts/Entities/StatementInterface.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Exception;
 
-interface StatementInterface extends UuidEntityInterface
+interface StatementInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const IMPORT_VALIDATION = 'import';
     public const DEFAULT_VALIDATION = 'Default';
@@ -61,16 +61,11 @@ interface StatementInterface extends UuidEntityInterface
      */
     public const MAP_FILE_EMPTY_DASHED = '---';
 
-    public function getId(): ?string;
-
     /**
      * @param string $id
      */
     public function setId($id);
 
-    /**
-     * @deprecated use {@link StatementInterface::getId()} instead
-     */
     public function getIdent(): ?string;
 
     /**

--- a/src/Contracts/Entities/StatementInterface.php
+++ b/src/Contracts/Entities/StatementInterface.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
-use League\Fractal\Resource\Collection;
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Exception;
 
 interface StatementInterface extends UuidEntityInterface, SegmentInterface
@@ -1639,5 +1639,7 @@ interface StatementInterface extends UuidEntityInterface, SegmentInterface
     public function isAnonymous(): bool;
 
     public function setAnonymous(bool $anonymous): StatementInterface;
+
+    public function removeSimilarStatementSubmitter(ProcedurePersonInterface $procedurePerson): void;
 
 }

--- a/src/Contracts/Entities/StatementInterface.php
+++ b/src/Contracts/Entities/StatementInterface.php
@@ -4,7 +4,1640 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface StatementInterface
+use DateTime;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\ArrayCollection;
+use Exception;
+
+interface StatementInterface extends UuidEntityInterface, SegmentInterface
 {
+    public const IMPORT_VALIDATION = 'import';
+    public const DEFAULT_VALIDATION = 'Default';
+    public const MANUAL_CREATE_VALIDATION = 'manual_create';
+
+    public const INTERNAL = 'internal';
+    public const EXTERNAL = 'external';
+
+    /**
+     * Type used for statements submitted via public participation functionalities.
+     */
+    public const SUBMIT_TYPE_SYSTEM = 'system';
+    // more submission types, see form_options.yml
+    public const SUBMIT_TYPE_EMAIL = 'email';
+    public const SUBMIT_TYPE_FAX = 'fax';
+    public const SUBMIT_TYPE_LETTER = 'letter';
+    public const SUBMIT_TYPE_EAKTE = 'eakte';
+    public const SUBMIT_TYPE_DECLARATION = 'declaration';
+    public const SUBMIT_TYPE_UNKNOWN = 'unknown';
+    public const SUBMIT_TYPE_UNSPECIFIED = 'unspecified';
+
+    /**
+     * For documentation, see Statement->publicVerifiedMapping.
+     */
+    public const PUBLICATION_NO_CHECK_SINCE_PERMISSION_DISABLED = 'no_check_permission_disabled';
+
+    /**
+     * For documentation, see {@link publicVerifiedMapping}.
+     */
+    public const PUBLICATION_NO_CHECK_SINCE_NOT_ALLOWED = 'no_check_since_not_allowed';
+
+    /**
+     * For documentation, see {@link publicVerifiedMapping}.
+     */
+    public const PUBLICATION_PENDING = 'publication_pending';
+
+    /**
+     * For documentation, see {@link publicVerifiedMapping}.
+     */
+    public const PUBLICATION_REJECTED = 'publication_rejected';
+
+    /**
+     * For documentation, see {@link publicVerifiedMapping}.
+     */
+    public const PUBLICATION_APPROVED = 'publication_approved';
+
+    /**
+     * One of probably three options to determine that there is no mapFile given.
+     */
+    public const MAP_FILE_EMPTY_DASHED = '---';
+
+    public function getId(): ?string;
+
+    /**
+     * @param string $id
+     */
+    public function setId($id);
+
+    /**
+     * @deprecated use {@link StatementInterface::getId()} instead
+     */
+    public function getIdent(): ?string;
+
+    /**
+     * @return StatementInterface
+     */
+    public function getParent();
+
+    /**
+     * Parent-Statement, of which this Statement was copied.
+     *
+     * @param StatementInterface $parent
+     *
+     * @return $this
+     */
+    public function setParent($parent);
+
+    /**
+     * @param StatementInterface $child
+     *
+     * @return $this
+     */
+    public function addChild($child);
+
+    /**
+     * @param StatementInterface $child
+     *
+     * @return $this
+     */
+    public function removeChild($child);
+
+    /**
+     * @param StatementInterface[] $children
+     *
+     * @return $this
+     */
+    public function setChildren($children);
+
+    /**
+     * @return string|null
+     */
+    public function getParentId();
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getChildren();
+
+    /**
+     * @return StatementInterface
+     */
+    public function getOriginal();
+
+    /**
+     * @param StatementInterface $original
+     */
+    public function setOriginal($original);
+
+    public function getOriginalId(): ?string;
+
+    /**
+     * Set priority.
+     *
+     * @param string $priority
+     */
+    public function setPriority($priority): StatementInterface;
+
+    /**
+     * Get priority.
+     */
+    public function getPriority(): string;
+
+    /**
+     * Get prioritySort.
+     *
+     * Rewrites emptystrings with "zzz" in order to move them last
+     * in sorted elasticsearch lists.
+     *
+     * @return string
+     */
+    public function getPrioritySort();
+
+    /**
+     * Add Priority Area.
+     *
+     * @param PriorityAreaInterface $priorityArea
+     *
+     * @return bool - true, if the given priorityArea was successful added to this statement
+     *              and this statement was successful added to the given priorityArea, otherwise false
+     */
+    public function addPriorityArea($priorityArea): bool;
+
+    /**
+     * Remove PriorityArea.
+     *
+     * @param PriorityAreaInterface $priorityArea
+     */
+    public function removePriorityArea($priorityArea);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getPriorityAreas();
+
+    public function getPriorityAreaKeys(): array;
+
+    public function getMunicipalityNames(): array;
+
+    public function getCountyNames(): array;
+
+    /**
+     * @param PriorityAreaInterface[]|ArrayCollection<int, PriorityAreaInterface> $priorityAreas
+     */
+    public function setPriorityAreas($priorityAreas);
+
+    /**
+     * Set externId.
+     *
+     * @param string $externId
+     */
+    public function setExternId($externId): StatementInterface;
+
+    public function getExternId(): string;
+
+    public function getInternId(): ?string;
+
+    /**
+     * @param string $internId
+     */
+    public function setInternId($internId): StatementInterface;
+
+    /**
+     * Set user.
+     *
+     * @param UserInterface $user
+     */
+    public function setUser($user): StatementInterface;
+
+    /**
+     * Get user.
+     *
+     * @return UserInterface
+     */
+    public function getUser();
+
+    /**
+     * @return string|null
+     */
+    public function getUserId();
+
+    /**
+     * Method for ES indexing.
+     *
+     * @return string
+     */
+    public function getUId();
+
+    /**
+     * Method for ES indexing.
+     *
+     * @return string
+     */
+    public function getUName();
+
+    /**
+     * Returns the name of the author!
+     *
+     * @return string
+     */
+    public function getUserName();
+
+    /**
+     * Set oId.
+     *
+     * @param OrgaInterface $organisation
+     */
+    public function setOrganisation($organisation): StatementInterface;
+
+    /**
+     * Get Organisation.
+     *
+     * Return value might somehow even be empty string
+     *
+     * @return OrgaInterface|string|null
+     */
+    public function getOrganisation();
+
+    /**
+     * Get Name of related Organisation.
+     */
+    public function getOrganisationName(): ?string;
+
+    /**
+     * All ways to create a statement as citizen, will lead to a related citizen organisation.
+     * Therefore, if there is a related organisation and is the related organisation is the
+     * default citizen organisation, this statement was submitted and authored by an citizen.
+     */
+    public function isSubmittedByCitizen(): bool;
+
+    /**
+     * All ways to create a statement as citizen, will lead to a related citizen organisation.
+     * Therefore, if there is no related organisation or the related organisation is not the
+     * default citizen organisation, this statement was submitted and authored by an organisation.
+     */
+    public function isSubmittedByOrganisation(): bool;
+
+    /**
+     * Follows the same logic as used in isSubmittedByOrganisation().
+     */
+    public function isAuthoredByOrganisation(): bool;
+
+    /**
+     * Follows the same logic as used in isSubmittedByCitizen().
+     */
+    public function isAuthoredByCitizen(): bool;
+
+    /**
+     * Get organisation ID.
+     */
+    public function getOId(): ?string;
+
+    /**
+     * Get Organisation Name.
+     *
+     * @return string
+     */
+    public function getOName();
+
+    /**
+     * Get Department Name.
+     *
+     * @return string
+     */
+    public function getDName();
+
+    /**
+     * Set procedure.
+     *
+     * @param ProcedureInterface $procedure
+     */
+    public function setProcedure($procedure): StatementInterface;
+
+    public function getProcedure(): ProcedureInterface;
+
+    /**
+     * Returns the ID of the related procedure.
+     *
+     * @return string
+     */
+    public function getProcedureId();
+
+    /**
+     * Get pId.
+     *
+     * @return string
+     */
+    public function getPId();
+
+    /**
+     * Set phase.
+     *
+     * @param string $phase
+     */
+    public function setPhase($phase): StatementInterface;
+
+    /**
+     * Get phase.
+     */
+    public function getPhase(): string;
+
+    /**
+     * Set status.
+     *
+     * @param string $status
+     */
+    public function setStatus($status): StatementInterface;
+
+    /**
+     * Get status.
+     *
+     * @return string
+     */
+    public function getStatus();
+
+    /**
+     * Set Created.
+     *
+     * @param DateTime $created
+     */
+    public function setCreated($created): StatementInterface;
+
+    /**
+     * Get Created.
+     *
+     * @return DateTime
+     */
+    public function getCreated();
+
+    /**
+     * Set modified.
+     *
+     * @param DateTime $modified
+     */
+    public function setModified($modified): StatementInterface;
+
+    /**
+     * Get modified.
+     *
+     * @return DateTime
+     */
+    public function getModified();
+
+    /**
+     * Set send.
+     *
+     * @param DateTime $send
+     */
+    public function setSend($send): StatementInterface;
+
+    /**
+     * Get send.
+     *
+     * @return DateTime
+     */
+    public function getSend();
+
+    /**
+     * Set sentAssessmentDate.
+     *
+     * @param DateTime $sentAssessmentDate
+     */
+    public function setSentAssessmentDate($sentAssessmentDate): StatementInterface;
+
+    /**
+     * Get sentAssessmentDate.
+     *
+     * @return DateTime
+     */
+    public function getSentAssessmentDate();
+
+    /**
+     * Set submit.
+     *
+     * @param DateTime $submit
+     */
+    public function setSubmit($submit): StatementInterface;
+
+    /**
+     * Get submit as Timestamp.
+     */
+    public function getSubmit(): int;
+
+    /**
+     * Get submit as Object.
+     *
+     * @return DateTime
+     */
+    public function getSubmitObject();
+
+    /**
+     * @return string
+     */
+    public function getSubmitDateString();
+
+    /**
+     * Set deletedDate.
+     *
+     * @param DateTime $deletedDate
+     */
+    public function setDeletedDate($deletedDate): StatementInterface;
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getCounties();
+
+    /**
+     * @param CountyInterface[]|ArrayCollection<int, CountyInterface> $counties
+     */
+    public function setCounties($counties);
+
+    /**
+     * Add County.
+     *
+     * @param CountyInterface $county
+     *
+     * @return bool - true, if the given county was successful added to this statement
+     *              and this statement was successful added to the given county, otherwise false
+     */
+    public function addCounty($county): bool;
+
+    /**
+     * Remove County.
+     *
+     * @param CountyInterface $county
+     */
+    public function removeCounty($county);
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getMunicipalities();
+
+    /**
+     * @param MunicipalityInterface[]|ArrayCollection<int, MunicipalityInterface> $municipalities
+     */
+    public function setMunicipalities($municipalities);
+
+    /**
+     * Add Municipality.
+     *
+     * @param MunicipalityInterface $municipality
+     *
+     * @return bool - true, if the given municipality was successful added to this statement
+     *              and this statement was successful added to the given municipality, otherwise false
+     */
+    public function addMunicipality($municipality): bool;
+
+    public function getFragments(): Collection;
+
+    /**
+     * @param StatementFragmentInterface[] $fragments
+     */
+    public function setFragments($fragments);
+
+    public function removeFragment(StatementFragmentInterface $fragment): void;
+
+    public function addFragment(StatementFragmentInterface $fragment): void;
+
+    /**
+     * Number of fragments that match a given filter when a search is applied
+     * Returns the number of all fragments if nothing is filtered or searched.
+     */
+    public function getFragmentsFilteredCount(): ?int;
+
+    /**
+     * Number of all fragments.
+     */
+    public function getFragmentsCount(): int;
+
+    /**
+     * @param int|null $fragmentsFilteredCount
+     */
+    public function setFragmentsFilteredCount($fragmentsFilteredCount);
+
+    /**
+     * @return array<int,string>
+     */
+    public function getFiles(): array;
+
+    /**
+     * @return array<int,string>
+     */
+    public function getFileNames(): array;
+
+    /**
+     * Attention. FileStrings are needed, which you can get from the FileContainerRepository.
+     * One could implement magic function __toString() in File that returns it.
+     * May typehint string will do it's thing.
+     *
+     * @param array $files
+     */
+    public function setFiles($files);
+
+    /**
+     * Remove Municipality.
+     *
+     * @param MunicipalityInterface $municipality
+     */
+    public function removeMunicipality($municipality);
+
+    /**
+     * Returns a text that describes in the name of whom this
+     * statement is going to be submitted.
+     *
+     * @return string
+     */
+    public function getRepresents();
+
+    /**
+     * Sets a text that describes in the name of whom this
+     * statement is going to be submitted.
+     *
+     * @param string $represents
+     */
+    public function setRepresents($represents): StatementInterface;
+
+    /**
+     * Returns wheter the validity and/or authority
+     * of this statements representative has been checked
+     * by a planner.
+     */
+    public function getRepresentationCheck(): int;
+
+    /**
+     * Sets wheter the validity and/or authority
+     * of this statements representative has been checked
+     * by a planner.
+     *
+     * @param bool $checked
+     */
+    public function setRepresentationCheck($checked): StatementInterface;
+
+    /**
+     * Get deletedDate.
+     *
+     * @return DateTime
+     */
+    public function getDeletedDate();
+
+    /**
+     * Set Deleted.
+     *
+     * @param bool $deleted
+     */
+    public function setDeleted($deleted): StatementInterface;
+
+    /**
+     * Get deleted.
+     */
+    public function getDeleted(): bool;
+
+    /**
+     * Is deleted.
+     */
+    public function isDeleted(): bool;
+
+    /**
+     * Tells Elasticsearch whether Entity should be indexed.
+     *
+     * @return bool
+     */
+    public function shouldBeIndexed();
+
+    /**
+     * Set negativeStatement.
+     *
+     * @param bool $negativeStatement
+     */
+    public function setNegativeStatement($negativeStatement): StatementInterface;
+
+    /**
+     * Get negativeStatement.
+     */
+    public function getNegativeStatement(): bool;
+
+    /**
+     * Set sentAssessment.
+     *
+     * @param bool $sentAssessment
+     */
+    public function setSentAssessment($sentAssessment): StatementInterface;
+
+    /**
+     * Get sentAssessment.
+     */
+    public function getSentAssessment(): bool;
+
+    /**
+     * Get publicAllowed.
+     * Convenience getter method.
+     *
+     **/
+    public function getPublicAllowed(): bool;
+
+    /**
+     * Set publicUseName.
+     *
+     * @param bool $publicUseName
+     */
+    public function setPublicUseName($publicUseName): StatementInterface;
+
+    /**
+     * Get publicUseName.
+     */
+    public function getPublicUseName(): bool;
+
+    /**
+     * Set publicVerified.
+     *
+     * @param string $publicVerified
+     */
+    public function setPublicVerified($publicVerified): StatementInterface;
+
+    /**
+     * Get publicVerified.
+     */
+    public function getPublicVerified(): string;
+
+    /**
+     * Get translation key of property publicVerified.
+     */
+    public function getPublicVerifiedTranslation(): string;
+
+    /**
+     * Get publicCheck. This code is solely for backward compatibility and waiting to be completely removed.
+     *
+     * @deprecated the information of $this->publicCheck is now completely transferred to this->publicVerified
+     */
+    public function getPublicCheck(): string;
+
+    /**
+     * Set publicStatement.
+     *
+     * @param string $publicStatement
+     */
+    public function setPublicStatement($publicStatement): StatementInterface;
+
+    /**
+     * Get publicStatement.
+     */
+    public function getPublicStatement(): string;
+
+    /**
+     * Set toSendPerMail.
+     *
+     * @param bool $toSendPerMail
+     */
+    public function setToSendPerMail($toSendPerMail): StatementInterface;
+
+    /**
+     * Get toSendPerMail.
+     */
+    public function getToSendPerMail(): bool;
+
+    /**
+     * Set title.
+     *
+     * @param string $title
+     */
+    public function setTitle($title): StatementInterface;
+
+    /**
+     * Get title.
+     */
+    public function getTitle(): string;
+
+    /**
+     * Set text.
+     *
+     * @param string $text
+     */
+    public function setText($text): StatementInterface;
+
+    /**
+     * Get text.
+     */
+    public function getText(): string;
+
+    public function getTextShort(): string;
+
+    /**
+     * Set recommendation.
+     *
+     * @param string $recommendation
+     */
+    public function setRecommendation($recommendation): StatementInterface;
+
+    /**
+     * Get recommendation.
+     */
+    public function getRecommendation(): string;
+
+    /**
+     * @param string $additionalRecommendationParagraphText
+     */
+    public function addRecommendationParagraph($additionalRecommendationParagraphText): StatementInterface;
+
+    public function getRecommendationShort(): string;
+
+    /**
+     * Set memo.
+     *
+     * @param string $memo
+     */
+    public function setMemo($memo): StatementInterface;
+
+    /**
+     * Get memo.
+     */
+    public function getMemo(): string;
+
+    /**
+     * Set feedback.
+     *
+     * @param string $feedback
+     */
+    public function setFeedback($feedback): StatementInterface;
+
+    /**
+     * Get feedback.
+     */
+    public function getFeedback(): string;
+
+    /**
+     * Set reasonParagraph.
+     *
+     * @param string $reasonParagraph
+     */
+    public function setReasonParagraph($reasonParagraph): StatementInterface;
+
+    /**
+     * @return Collection<int, StatementAttachmentInterface>
+     */
+    public function getAttachments(): Collection;
+
+    /**
+     * @param Collection<int, StatementAttachmentInterface> $attachments
+     */
+    public function setAttachments(Collection $attachments): void;
+
+    public function addAttachment(StatementAttachmentInterface $attachment): self;
+
+    /**
+     * Get reasonParagraph.
+     */
+    public function getReasonParagraph(): string;
+
+    /**
+     * Set planningDocument.
+     *
+     * @param string $planningDocument
+     */
+    public function setPlanningDocument($planningDocument): StatementInterface;
+
+    /**
+     * Get planningDocument.
+     *
+     * @return string
+     */
+    public function getPlanningDocument();
+
+    /**
+     * Set file.
+     *
+     * @param string $file
+     */
+    public function setFile($file): StatementInterface;
+
+    /**
+     * Get file.
+     *
+     * @return string
+     *
+     * @deprecated this was basically removed (replaced with {@link FileContainerInterface}) but may be still used somewhere
+     */
+    public function getFile();
+
+    /**
+     * Set mapFile.
+     *
+     * @param string $mapFile
+     */
+    public function setMapFile($mapFile): StatementInterface;
+
+    /**
+     * Get mapFile.
+     *
+     * @return string|null In the database beside an actual map file string in the
+     *                     form of 'Map_DRAFT_STATEMENT_UUID.png:FILE_UUID' the
+     *                     value may be null or an empty string as well.
+     */
+    public function getMapFile(): ?string;
+
+    /**
+     * Set countyNotified.
+     *
+     * @param bool $cn
+     */
+    public function setCountyNotified($cn): StatementInterface;
+
+    /**
+     * Get countyNotified.
+     *
+     * @return bool
+     */
+    public function getCountyNotified();
+
+    /**
+     * @return ParagraphVersionInterface|null
+     */
+    public function getParagraph();
+
+    /**
+     * @param ParagraphVersionInterface|null $paragraph
+     */
+    public function setParagraph($paragraph);
+
+    /**
+     * Get paragraphId.
+     *
+     * @return string
+     */
+    public function getParagraphId();
+
+    /**
+     * Get paragraphTitle.
+     *
+     * @return string
+     */
+    public function getParagraphTitle();
+
+    /**
+     * Get paragraphOrder.
+     *
+     * @return string
+     */
+    public function getParagraphOrder();
+
+    /**
+     * Get paragraphParentId.
+     *
+     * @return string
+     */
+    public function getParagraphParentId();
+
+    /**
+     * @return string|null returns the title of the parent paragraph (the paragraph of the paragraph version)
+     */
+    public function getParagraphParentTitle();
+
+    /**
+     * @return string|null returns the title of the parent document (the document of the document version)
+     */
+    public function getDocumentParentTitle();
+
+    /**
+     * @return SingleDocumentVersionInterface|null
+     */
+    public function getDocument();
+
+    /**
+     * @param SingleDocumentVersionInterface|null $documentVersion
+     */
+    public function setDocument($documentVersion);
+
+    /**
+     * Get documentId.
+     *
+     * @return string
+     */
+    public function getDocumentId();
+
+    /**
+     * Get documentTitle.
+     *
+     * @return string
+     */
+    public function getDocumentTitle();
+
+    /**
+     * Get documentHash.
+     *
+     * @return string
+     */
+    public function getDocumentHash();
+
+    /**
+     * Get elementId.
+     *
+     * @return string
+     */
+    public function getElementId();
+
+    /**
+     * Get elementOrder.
+     *
+     * @return int
+     */
+    public function getElementOrder();
+
+    /**
+     * Get elementTitle.
+     *
+     * @return string
+     */
+    public function getElementTitle();
+
+    /**
+     * Get categoryType.
+     *
+     * Returns the category of the element that this statement refers to
+     *
+     * @return string
+     */
+    public function getElementCategory();
+
+    /**
+     * @return ElementsInterface|null
+     */
+    public function getElement();
+
+    /**
+     * @param ElementsInterface|null $element
+     */
+    public function setElement($element);
+
+    /**
+     * Set polygon.
+     *
+     * @param string $polygon
+     *
+     * @return StatementInterface
+     */
+    public function setPolygon($polygon);
+
+    /**
+     * Get polygon.
+     *
+     * @return string
+     */
+    public function getPolygon();
+
+    /**
+     * Set DraftStatement.
+     *
+     * @param DraftStatementInterface $draftStatement
+     *
+     * @return StatementInterface
+     */
+    public function setDraftStatement($draftStatement);
+
+    /**
+     * Get DraftStatement.
+     *
+     * @return DraftStatementInterface
+     */
+    public function getDraftStatement();
+
+    /**
+     * Get DraftStatement Id.
+     *
+     * @return string
+     */
+    public function getDraftStatementId();
+
+    public function getMeta(): StatementMetaInterface;
+
+    public function setMeta(StatementMetaInterface $meta): void;
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getStatementAttributes();
+
+    /**
+     * @return StatementVersionFieldInterface
+     */
+    public function getVersion();
+
+    /**
+     * @param StatementVersionFieldInterface $version
+     */
+    public function setVersion($version);
+
+    /**
+     * @return Collection<int,StatementVoteInterface>
+     */
+    public function getVotes();
+
+    /**
+     * To ensure correct handling of votes, use repository method instead using this method directly.
+     * The repository method, can handle a list of given votes and decide which of the given votes
+     * have to be created or updated and which of the current votes have to be deleted.
+     *
+     * @param StatementVoteInterface[] $votes
+     */
+    public function setVotes($votes);
+
+    /**
+     * Returns number of votes for easier use in ES.
+     */
+    public function getVotesNum(): int;
+
+    /**
+     * Returns number of likes for easier use in ES.
+     *
+     * @return int
+     */
+    public function getLikesNum();
+
+    /**
+     * @return StatementLikeInterface[]
+     */
+    public function getLikes();
+
+    /**
+     * Set Tags.
+     *
+     * @param TagInterface[] $tags
+     */
+    public function setTags($tags): StatementInterface;
+
+    /**
+     * Add Tag.
+     *
+     * @return bool - true, if the given tag was successful added to this statement
+     *              and this statement was successful added to the given tag, otherwise false
+     */
+    public function addTag(TagInterface $tag): bool;
+
+    /**
+     * @param array<int, TagInterface> $tags
+     */
+    public function addTags(array $tags): void;
+
+    /**
+     * @param array<int, TagInterface> $tags
+     */
+    public function removeTags(array $tags): void;
+
+    /**
+     * Remove Tag.
+     *
+     * @return StatementInterface
+     */
+    public function removeTag(TagInterface $tag);
+
+    /**
+     * Get Tags.
+     */
+    public function getTags(): Collection;
+
+    /**
+     * Returns the names of all Tags assigned to this Statement.
+     *
+     * @return array()
+     */
+    public function getTagNames(): array;
+
+    /**
+     * Returns the Ids of all Tags assigned to this Statement.
+     *
+     * @return array()
+     */
+    public function getTagIds(): array;
+
+    /**
+     * Returns the names of all Topics that are related with this Statement.
+     *
+     * @return array()
+     */
+    public function getTopicNames();
+
+    /**
+     * VoteStatskanzlei
+     * Get the StK-vote of this statement.
+     *
+     * @return string
+     */
+    public function getVoteStk();
+
+    /**
+     * Set the StK-vote of this statement
+     * Kind of vote advice.
+     *
+     * @param string|null $voteStk
+     *
+     * @throws Exception
+     */
+    public function setVoteStk($voteStk): StatementInterface;
+
+    /**
+     * VotePlanungs...behörde?!/büro
+     * Get the planners vote of this statement.
+     */
+    public function getVotePla(): ?string;
+
+    /**
+     * Set the planners vote of this statement.
+     *
+     * @param string|null $votePla
+     *
+     * @throws Exception
+     */
+    public function setVotePla($votePla): StatementInterface;
+
+    public function getAllowedVoteValues(): array;
+
+    /**
+     * @return string
+     */
+    public function getSubmitType();
+
+    /**
+     * @param string $submitType
+     */
+    public function setSubmitType($submitType);
+
+    /**
+     * This field ist transformed during populate to Elasticsearch and Doctrine fetch.
+     */
+    public function getSubmitTypeTranslated(): string;
+
+    public function setSubmitTypeTranslated(string $submitTypeTranslated): StatementInterface;
+
+    /**
+     * @return UserInterface|null
+     */
+    public function getAssignee();
+
+    public function getAssigneeId(): ?string;
+
+    /**
+     * @param UserInterface|null $assignee
+     */
+    public function setAssignee($assignee);
+
+    /**
+     * Returns the cluster which this Statement belongs to.
+     *
+     * @return ArrayCollection
+     */
+    public function getCluster();
+
+    /**
+     * Add this Statement to a cluster of Statements
+     * If one of the given statements already a member of a cluster, this membership will be replaced!
+     *
+     * @param StatementInterface[] $statements
+     *
+     * @return $this
+     */
+    public function setCluster($statements);
+
+    /**
+     * @return StatementInterface
+     */
+    public function getHeadStatement();
+
+    /**
+     * @return string|null
+     */
+    public function getHeadStatementId();
+
+    /**
+     * @param StatementInterface $headStatement
+     *
+     * @return $this
+     */
+    public function setHeadStatement($headStatement);
+
+    /**
+     * Determines if this Statement is the head of a cluster.
+     *
+     * @return bool true if this Statement is the head of a cluster, otherwise false
+     */
+    public function hasClusterMember();
+
+    /**
+     * Determines if this Statement belongs to a cluster.
+     *
+     * @return bool true if this Statement belongs to a cluster, otherwise false.s
+     */
+    public function isInCluster(): bool;
+
+    /**
+     * Add a Statement to the cluster of this Statement.
+     *
+     * @param StatementInterface $statement
+     *
+     * @return StatementInterface|bool - false if this statement not a head of a cluster, otherwise this statement
+     */
+    public function addStatement($statement);
+
+    /**
+     * @return int number of Statements belongs to the cluster
+     */
+    public function getNumberOfStatementsInCluster();
+
+    /**
+     * Removes the given Statement from his cluster if it is actually a element of a cluster.
+     * Also set the headStatement of the given Statement to null.
+     *
+     * @return bool - true if the given Statement is a element of a cluster
+     *              and was successfully removed, otherwise false
+     */
+    public function removeClusterElement(StatementInterface $statementToRemove);
+
+    /**
+     * Removes this Statement from his cluster if it is actually a element of a cluster.
+     * Also set the headStatement if this Statement to null.
+     *
+     * @return bool - true if the given Statement is a element of a cluster
+     *              and was successfully removed, otherwise false
+     */
+    public function detachFromCluster();
+
+    /**
+     * Load Authored Date from MetaData as Timestamp.
+     *
+     * @return int - Timestamp
+     */
+    public function getAuthoredDate();
+
+    /**
+     * @return string
+     */
+    public function getAuthoredDateString();
+
+    /**
+     * Yields the type of this statement.
+     *
+     * Returns wheter the statement is a regular statement ('N'),
+     * A cluster ('G')
+     * Or a manually entered statement ('M')
+     */
+    public function getType(): string;
+
+    /**
+     * @return string|null
+     *
+     * @throws Exception
+     */
+    public function getConsentSubmitterId();
+
+    /**
+     * @return UserInterface|null
+     *
+     * @throws Exception
+     */
+    public function getConsentAuthor();
+
+    /**
+     * Considers if a GDPR consent was given at some time as well as if the consent was revoked.
+     *
+     * The original statement will be used if this statement isn't one.
+     *
+     * @return bool true if the consent was given and not revoked; false otherwise
+     */
+    public function isConsented(): bool;
+
+    /**
+     * Uses the GdprConsent attached to its $original Statement or its own GdprConsent if the $original
+     * Statement is null. If both are null a fake GdprConsent (consentReceived and consentRevoked both false)
+     * will be returned. This is done as it is hard to determine the actual consent of some original statements
+     * (for example original cluster statements).
+     *
+     * @return GdprConsentInterface|null
+     */
+    public function getGdprConsent();
+
+    /**
+     * @return bool true if the consent was revoked, regardless of if it was received at all; false otherwise
+     */
+    public function isConsentRevoked(): bool;
+
+    /**
+     * @return bool true if the consent was received, regardless of if it was revoked later; false otherwise
+     */
+    public function isConsentReceived(): bool;
+
+    public function isManual(): bool;
+
+    /**
+     * @param bool $isManual
+     */
+    public function setManual($isManual = true);
+
+    public function isOriginal(): bool;
+
+    /**
+     * @return int
+     */
+    public function getNumberOfAnonymVotes();
+
+    /**
+     * @param int $numberOfAnonymVotes
+     */
+    public function setNumberOfAnonymVotes($numberOfAnonymVotes);
+
+    public function isClusterStatement(): bool;
+
+    /**
+     * Because of headStatements are only used as container and will be deleted on resolving a cluster,
+     * there is no need to set this flag to false.
+     *
+     * @param bool $isCluster
+     */
+    public function setClusterStatement($isCluster): StatementInterface;
+
+    public function getAuthorName(): string;
+    /**
+     * @return string|null
+     */
+    public function getAuthorId();
+
+    /**
+     * @return UserInterface|null
+     */
+    public function getAuthor();
+
+    public function getOrgaPostalCode(): string;
+
+    public function getOrgaCity(): string;
+
+    public function getOrgaStreet(): string;
+
+    /**
+     * @return string|null
+     */
+    public function getOrgaEmail();
+
+    public function setOrgaEmail(string $emailAddress): self;
+
+    public function getOrgaPhoneNumber(): string;
+
+    /**
+     * @return ProcedureInterface|null
+     */
+    public function getMovedToProcedure();
+
+    /**
+     * @param StatementInterface|null $movedStatement
+     */
+    public function setMovedStatement($movedStatement);
+
+    /**
+     * @return StatementInterface|null
+     */
+    public function getMovedStatement();
+
+    /**
+     * @return string|null
+     */
+    public function getMovedStatementId();
+
+    public function isPlaceholder(): bool;
+
+    public function wasMoved(): bool;
+
+    /**
+     * @return StatementInterface|null
+     */
+    public function getPlaceholderStatement();
+
+    /**
+     * @param StatementInterface|null $placeholderStatement
+     */
+    public function setPlaceholderStatement($placeholderStatement);
+
+    /**
+     * @return ProcedureInterface|null
+     */
+    public function getMovedFromProcedure();
+
+    /**
+     * @return string|null
+     */
+    public function getMovedFromProcedureId();
+
+    /**
+     * @return string|null
+     */
+    public function getMovedFromProcedureName();
+
+    /**
+     * @return string|null
+     */
+    public function getMovedToProcedureId();
+
+    public function getMovedToProcedureName(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getFormerExternId();
+
+    /**
+     * @return string|null
+     */
+    public function getDocumentParentId();
+
+    /**
+     * @return string|null
+     */
+    public function getProcedureOwningOrgaId();
+
+    /**
+     * Determines if this statement was created by an institution.
+     * <p>
+     * This is the case if the 'manual' field is set to false and the 'publicStatement' field is set to {@link INTERNAL}
+     * as manual statements are created by planners and statements directly created by citizens are always {@link EXTERNAL}.
+     */
+    public function isCreatedByInvitableInstitution(): bool;
+
+    public function isCreatedByCitizen(): bool;
+
+    public function isPlannerCreatedCitizenStatement(): bool;
+
+    public function isPlannerCreatedInvitableInstitutionStatement(): bool;
+
+    /**
+     * Get the email address used to submit this statement.
+     */
+    public function getSubmitterEmailAddress(): ?string;
+
+    /**
+     * Attempts to reverse the logic in {@link StatementInterface::getSubmitterEmailAddress()}.
+     */
+    public function setSubmitterEmailAddress(string $emailAddress): self;
+
+    public function getName(): string;
+
+    /**
+     * @param string|null $name
+     */
+    public function setName($name);
+
+    /**
+     * Determines if this statement is the copy of another (non-original) statement.
+     */
+    public function isCopy(): bool;
+
+    /**
+     * Returns the Id of the submitter of this statement, if existing.
+     * Will return null, in case of submitter unregistered User (or dummy user User::ANONYMOUS_USER_ID).
+     *
+     * @return string|null
+     */
+    public function getSubmitterId();
+    /**
+     * Returns the Name of the submitter of this statement, if existing.
+     * Will return null, in case of submitter unregistered User (or dummy user User::ANONYMOUS_USER_ID).
+     */
+    public function getSubmitterName(): ?string;
+
+    /**
+     * Set GdprConsent to this Statement.
+     *
+     * @param GdprConsentInterface|null $gdprConsent
+     *
+     */
+    public function setGdprConsent($gdprConsent);
+
+    /**
+     * Check if this statement was submitted and authored by an unregistered citizen.
+     *
+     * @return bool true, if this statement was submitted by an unregistered citizen, otherwise false
+     */
+    public function hasBeenSubmittedAndAuthoredByUnregisteredCitizen(): bool;
+
+    /**
+     * Check if this statement was submitted and authored by a registered citizen.
+     *
+     * @return bool true, if this statement was submitted by an registered citizen, otherwise false
+     */
+    public function hasBeenSubmittedAndAuthoredByRegisteredCitizen(): bool;
+
+    /**
+     * Check if this statement was submitted and authored by a "InvitableInstitutionKoordinator".
+     *
+     * @return bool true, if this statement was submitted by an "InvitableInstitutionKoordinator", otherwise false
+     */
+    public function hasBeenSubmittedAndAuthoredByInvitableInstitutionKoordinator(): bool;
+
+    /**
+     * Check if this statement was authored by a "InstitutionSachbearbeiter".
+     * This implicit means, that this statement has be submitted by InstitutionKoordinator!
+     *
+     * @return bool true, if this statement was submitted by an "InstitutionSachbearbeiter", otherwise false
+     */
+    public function hasBeenAuthoredByInstitutionSachbearbeiterAndSubmittedByInstitutionKoordinator(): bool;
+
+    public function isSubmitter(string $userId): bool;
+
+    public function isAuthor(string $userId): bool;
+
+    public function setReplied(bool $replied): void;
+
+    public function isReplied(): bool;
+
+    /**
+     * Needed to create a grouped structure for an export in createElementsGroupStructure2().
+     * This method allows to create a group structure with paragraphs and documents on the same level.
+     */
+    public function getParagraphParentIdOrDocumentParentId(): ?string;
+
+    /**
+     * Needed to create a grouped structure for an export in createElementsGroupStructure2().
+     * This method allows to create a group structure with paragraphs and documents on the same level.
+     */
+    public function getParagraphParentTitleOrDocumentParentTitle(): ?string;
+
+    public function setDraftsListJson(string $json): void;
+
+    /**
+     * @return string May be empty if none was set yet
+     */
+    public function getDraftsListJson(): string;
+
+    /**
+     * @return Collection<int, SegmentInterface>
+     */
+    public function getSegmentsOfStatement(): Collection;
+
+    /**
+     * @param Collection<int, SegmentInterface> $segmentsOfStatement
+     */
+    public function setSegmentsOfStatement(Collection $segmentsOfStatement): void;
+
+    public function isAlreadySegmented(): bool;
+
+    /**
+     * Returns true if the Entity is implementing a Segment.
+     */
+    public function isSegment(): bool;
+
+    /**
+     * @return Collection<int, OriginalStatementAnonymizationInterface>
+     */
+    public function getAnonymizations(): Collection;
+
+    /**
+     * @param Collection<int, OriginalStatementAnonymizationInterface> $anonymizations
+     */
+    public function setAnonymizations(Collection $anonymizations): void;
+
+    /**
+     * @return bool True if this statement has at least one {@link OriginalStatementAnonymizationInterface}
+     *              entry in which the submitter or author data were deleted from the meta data.
+     *              False otherwise. This will not take author/submitter data anonymizations in
+     *              the statement text into account.
+     */
+    public function isSubmitterAndAuthorMetaDataAnonymized(): bool;
+
+    /**
+     * @return bool True if this statement has at least one {@link OriginalStatementAnonymizationInterface}
+     *              entry in which text passages in {@link text} were anonymized. False
+     *              otherwise.
+     */
+    public function isTextPassagesAnonymized(): bool;
+
+    /**
+     * @return bool True if this statement has at least one {@link OriginalStatementAnonymizationInterface}
+     *              entry in which attachments were deleted. False otherwise.
+     */
+    public function isAttachmentsDeleted(): bool;
+
+    public function getSegmentationPiRetries(): int;
+
+    public function incrementSegmentationPiRetries(): void;
+
+    /**
+     * Returns the Pdf the Statement was created from or null if there is none.
+     */
+    public function getOriginalFile(): ?FileInterface;
+
+    public function getPiSegmentsProposalResourceUrl(): ?string;
+
+    public function setPiSegmentsProposalResourceUrl(?string $piSegmentsProposalResourceUrl): void;
+
+    public function hasDefaultGuestUser(): bool;
+
+    public function getSubmitterPhoneNumber(): string;
+
+    /**
+     * @return Collection<int, ProcedurePersonInterface>
+     */
+    public function getSimilarStatementSubmitters(): Collection;
+
+    /**
+     * @param Collection<int, ProcedurePersonInterface> $similarStatementSubmitters
+     */
+    public function setSimilarStatementSubmitters(Collection $similarStatementSubmitters): StatementInterface;
+
+    public function isAnonymous(): bool;
+
+    public function setAnonymous(bool $anonymous): StatementInterface;
 
 }

--- a/src/Contracts/Entities/StatementInterface.php
+++ b/src/Contracts/Entities/StatementInterface.php
@@ -66,8 +66,6 @@ interface StatementInterface extends UuidEntityInterface, CoreEntityInterface
      */
     public function setId($id);
 
-    public function getIdent(): ?string;
-
     /**
      * @return StatementInterface
      */

--- a/src/Contracts/Entities/StatementLikeInterface.php
+++ b/src/Contracts/Entities/StatementLikeInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface StatementLikeInterface extends UuidEntityInterface
+{
+    /**
+     * @param string $id
+     *
+     * @return StatementLikeInterface
+     */
+    public function setId($id);
+
+    /**
+     * @return StatementInterface
+     */
+    public function getStatement();
+
+    /**
+     * @param StatementInterface $statement
+     *
+     * @return StatementLikeInterface
+     */
+    public function setStatement($statement);
+
+    /**
+     * @return UserInterface
+     */
+    public function getUser();
+
+    /**
+     * @param UserInterface $user
+     *
+     * @return StatementLikeInterface
+     */
+    public function setUser($user);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedDate();
+
+    /**
+     * @param DateTime $createdDate
+     *
+     * @return StatementLikeInterface
+     */
+    public function setCreatedDate($createdDate);
+
+}

--- a/src/Contracts/Entities/StatementMetaInterface.php
+++ b/src/Contracts/Entities/StatementMetaInterface.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface StatementMetaInterface extends UuidEntityInterface
+{
+    public const USER_GROUP = 'userGroup';
+    public const USER_ORGANISATION = 'userOrganisation';
+    public const USER_POSITION = 'userPosition';
+    public const USER_STATE = 'userState';
+    public const SUBMITTER_ROLE = 'submitterRole';
+    public const USER_PHONE = 'userPhone';
+    public const SUBMITTER_ROLE_CITIZEN = 'citizen';
+    public const SUBMITTER_ROLE_PUBLIC_AGENCY = 'publicagency';
+
+    /**
+     * @param string $id
+     */
+    public function setId($id);
+
+    public function getId(): ?string;
+
+    /**
+     * Set author.
+     *
+     * @return StatementMetaInterface
+     */
+    public function setStatement(StatementInterface $statement);
+
+    /**
+     * Get Statement.
+     *
+     * @return StatementInterface
+     */
+    public function getStatement();
+
+    /**
+     * @return string
+     */
+    public function getStatementId();
+
+    /**
+     * Set author.
+     *
+     * @param string $authorName
+     */
+    public function setAuthorName($authorName): self;
+
+    public function getAuthorName(): string;
+
+    public function setAuthorFeedback(bool $authorFeedback): self;
+
+    public function getAuthorFeedback(): bool;
+
+    /**
+     * Set SubmitUser.
+     *
+     * @param string|null $submitUId
+     */
+    public function setSubmitUId($submitUId): self;
+
+    /**
+     * Get submitUser.
+     *
+     * @return string
+     */
+    public function getSubmitUId(): ?string;
+
+    public function getSubmitName(): string;
+
+    /**
+     * @param string $submitName
+     */
+    public function setSubmitName($submitName): void;
+
+    /**
+     * Get submitter LastName.
+     * Algorithm is rather stupid, cannot cope with "von und zu Itzstein" or "da silva".
+     *
+     * This method is used to index data into elasticsearch and not obviously called via PHP.
+     */
+    public function getSubmitLastName(): string;
+
+    /**
+     * Set OrgaName.
+     *
+     * @param string $orgaName
+     */
+    public function setOrgaName($orgaName): self;
+
+    /**
+     * Get orgaName.
+     */
+    public function getOrgaName(): string;
+
+    /**
+     * Set orgaDepartmentName.
+     *
+     * @param string $orgaDepartmentName
+     */
+    public function setOrgaDepartmentName($orgaDepartmentName): self;
+
+    /**
+     * Get orgaDepartmentName.
+     */
+    public function getOrgaDepartmentName(): string;
+
+    /**
+     * Set orgaCaseWorkerName.
+     *
+     * @param string $caseWorkerName
+     *
+     * @return StatementMetaInterface
+     */
+    public function setCaseWorkerName($caseWorkerName);
+
+    /**
+     * Get orgaCaseWorkerName.
+     *
+     * @return string
+     */
+    public function getCaseWorkerName();
+
+    /**
+     * Get orgaCaseWorker LastName.
+     * Algorithm is rather stupid, cannot cope with "von und zu Itzstein" or "da silva".
+     *
+     * @return string
+     */
+    public function getCaseWorkerLastName();
+
+    /**
+     * Set orgaStreet.
+     *
+     * @param string $orgaStreet
+     *
+     * @return StatementMetaInterface
+     */
+    public function setOrgaStreet($orgaStreet);
+
+    /**
+     * Get orgaStreet.
+     */
+    public function getOrgaStreet(): string;
+
+    /**
+     * Set orgaPostalCode.
+     *
+     * @param string $orgaPostalCode
+     *
+     * @return StatementMetaInterface
+     */
+    public function setOrgaPostalCode($orgaPostalCode);
+
+    /**
+     * Get orgaPostalCode.
+     */
+    public function getOrgaPostalCode(): string;
+
+    /**
+     * Set orgaCity.
+     *
+     * @param string $orgaCity
+     *
+     * @return StatementMetaInterface
+     */
+    public function setOrgaCity($orgaCity);
+
+    /**
+     * Get orgaCity.
+     */
+    public function getOrgaCity(): string;
+
+    /**
+     * Set orgaEmail.
+     *
+     * @param string $orgaEmail
+     *
+     * @return StatementMetaInterface
+     */
+    public function setOrgaEmail($orgaEmail);
+
+    /**
+     * Get orgaEmail.
+     *
+     * @return string
+     */
+    public function getOrgaEmail();
+
+    /**
+     * get authoredDate as timestamp.
+     *
+     * @return int
+     */
+    public function getAuthoredDate();
+
+    /**
+     * @return DateTime
+     */
+    public function getAuthoredDateObject();
+
+    /**
+     * @param DateTime|null $authoredDate
+     */
+    public function setAuthoredDate($authoredDate);
+
+    /**
+     * @return string
+     */
+    public function getSubmitOrgaId();
+
+    /**
+     * @param string $submitOrgaId
+     */
+    public function setSubmitOrgaId($submitOrgaId);
+
+    /**
+     * @param string $key
+     *
+     * @return mixed|null
+     */
+    public function getMiscDataValue($key);
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return StatementMetaInterface
+     */
+    public function setMiscDataValue($key, $value);
+
+    /**
+     * @return array
+     */
+    public function getMiscData();
+
+    /**
+     * @param array $miscData
+     */
+    public function setMiscData($miscData);
+
+    /**
+     * Elasticsearch indexvariable project specific.
+     *
+     * @return string|null
+     */
+    public function getUserGroup();
+
+    /**
+     * Elasticsearch indexvariable project specific.
+     *
+     * @return string|null
+     */
+    public function getUserPosition();
+
+    /**
+     * Elasticsearch indexvariable project specific.
+     *
+     * @return string|null
+     */
+    public function getUserOrganisation();
+
+    /**
+     * Elasticsearch indexvariable project specific.
+     *
+     * @return string|null
+     */
+    public function getUserState();
+
+    public function getHouseNumber(): string;
+
+    public function setHouseNumber(string $houseNumber): void;
+
+}

--- a/src/Contracts/Entities/StatementMetaInterface.php
+++ b/src/Contracts/Entities/StatementMetaInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface StatementMetaInterface extends UuidEntityInterface
+interface StatementMetaInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const USER_GROUP = 'userGroup';
     public const USER_ORGANISATION = 'userOrganisation';
@@ -19,8 +19,6 @@ interface StatementMetaInterface extends UuidEntityInterface
      * @param string $id
      */
     public function setId($id);
-
-    public function getId(): ?string;
 
     /**
      * Set author.

--- a/src/Contracts/Entities/StatementVersionFieldInterface.php
+++ b/src/Contracts/Entities/StatementVersionFieldInterface.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface StatementVersionFieldInterface extends UuidEntityInterface
+{
+    /**
+     * Set uId.
+     *
+     * @param string $userIdent
+     *
+     * @return StatementVersionFieldInterface
+     */
+    public function setUserIdent($userIdent);
+
+    /**
+     * Get uId.
+     *
+     * @return string
+     */
+    public function getUserIdent();
+
+    /**
+     * Set uName.
+     *
+     * @param string $userName
+     *
+     * @return StatementVersionFieldInterface
+     */
+    public function setUserName($userName);
+
+    /**
+     * Get uName.
+     *
+     * @return string
+     */
+    public function getUserName();
+
+    /**
+     * Set sId.
+     *
+     * @param string $sessionIdent
+     *
+     * @return StatementVersionFieldInterface
+     */
+    public function setSessionIdent($sessionIdent);
+
+    /**
+     * Get sId.
+     *
+     * @return string
+     */
+    public function getSessionIdent();
+
+    /**
+     * Set svName.
+     *
+     * @param string $name
+     *
+     * @return StatementVersionFieldInterface
+     */
+    public function setName($name);
+
+    /**
+     * Get svName.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Set svType.
+     *
+     * @param string $type
+     *
+     * @return StatementVersionFieldInterface
+     */
+    public function setType($type);
+
+    /**
+     * Get svType.
+     *
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * Set svValue.
+     *
+     * @param string $value
+     *
+     * @return StatementVersionFieldInterface
+     */
+    public function setValue($value);
+
+    /**
+     * Get svValue.
+     *
+     * @return string
+     */
+    public function getValue();
+
+    /**
+     * Set svCreatedDate.
+     *
+     * @param DateTime $created
+     *
+     * @return StatementVersionFieldInterface
+     */
+    public function setCreated($created);
+
+    /**
+     * Get svCreatedDate.
+     *
+     * @return DateTime
+     */
+    public function getCreated();
+
+    /**
+     * Set st.
+     *
+     * @param StatementInterface $statement
+     *
+     * @return StatementVersionFieldInterface
+     */
+    public function setStatement(StatementInterface $statement = null);
+
+    /**
+     * Get st.
+     *
+     * @return StatementInterface
+     */
+    public function getStatement();
+
+    /**
+     * @return string
+     */
+    public function getStatementIdent();
+
+}

--- a/src/Contracts/Entities/StatementVoteInterface.php
+++ b/src/Contracts/Entities/StatementVoteInterface.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface StatementVoteInterface extends UuidEntityInterface
+{
+    /**
+     * @return StatementInterface
+     */
+    public function getStatement();
+
+    /**
+     * @param StatementInterface $statement
+     *
+     * @return StatementVoteInterface
+     */
+    public function setStatement($statement);
+
+    /**
+     * @return UserInterface|null
+     */
+    public function getUser();
+
+    /**
+     * @param UserInterface $user
+     *
+     * @return StatementVoteInterface
+     */
+    public function setUser($user);
+
+    /**
+     * @return string
+     */
+    public function getUId();
+
+    /**
+     * @return string
+     */
+    public function getFirstName();
+
+    /**
+     * @param string $firstName
+     *
+     * @return StatementVoteInterface
+     */
+    public function setFirstName($firstName);
+
+    /**
+     * @return string
+     */
+    public function getLastName();
+
+    /**
+     * @param string $lastName
+     *
+     * @return StatementVoteInterface
+     */
+    public function setLastName($lastName);
+
+    /**
+     * Get concatenated First and Lastname. Used in Elasticsearch.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @return bool
+     */
+    public function getActive();
+
+    /**
+     * @param bool $active
+     *
+     * @return StatementVoteInterface
+     */
+    public function setActive($active);
+
+    /**
+     * @return bool
+     */
+    public function getDeleted();
+
+    /**
+     * @param bool $deleted
+     *
+     * @return StatementVoteInterface
+     */
+    public function setDeleted($deleted);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedDate();
+
+    /**
+     * @param DateTime $createdDate
+     *
+     * @return StatementVoteInterface
+     */
+    public function setCreatedDate($createdDate);
+
+    /**
+     * @return DateTime
+     */
+    public function getModifiedDate();
+
+    /**
+     * @param DateTime $modifiedDate
+     *
+     * @return StatementVoteInterface
+     */
+    public function setModifiedDate($modifiedDate);
+
+    /**
+     * @return DateTime
+     */
+    public function getDeletedDate();
+
+    /**
+     * @param DateTime $deletedDate
+     *
+     * @return StatementVoteInterface
+     */
+    public function setDeletedDate($deletedDate);
+
+    /**
+     * @return bool
+     */
+    public function isManual();
+
+    /**
+     * @param bool $manual
+     */
+    public function setManual($manual);
+
+    /**
+     * @return string
+     */
+    public function getOrganisationName();
+
+    /**
+     * @param string $organisationName
+     */
+    public function setOrganisationName($organisationName);
+
+    /**
+     * @return string
+     */
+    public function getDepartmentName();
+
+    /**
+     * @param string $departmentName
+     */
+    public function setDepartmentName($departmentName);
+
+    /**
+     * @return string
+     */
+    public function getUserName();
+
+    /**
+     * @param string $userName
+     */
+    public function setUserName($userName);
+
+    /**
+     * @return string|null Will either be the address of the user that voted, a manually entered
+     *                     address for that vote or null
+     */
+    public function getUserMail();
+
+    /**
+     * @param string $userMail
+     */
+    public function setUserMail($userMail);
+
+    /**
+     * @return string
+     */
+    public function getUserPostcode();
+
+    /**
+     * @param string $userPostcode
+     */
+    public function setUserPostcode($userPostcode);
+
+    /**
+     * @return string
+     */
+    public function getUserCity();
+
+    /**
+     * @param string $userCity
+     */
+    public function setUserCity($userCity);
+
+    public function isCreatedByCitizen(): bool;
+
+    public function setCreatedByCitizen(bool $createdByCitizen): void;
+}

--- a/src/Contracts/Entities/SurveyInterface.php
+++ b/src/Contracts/Entities/SurveyInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use League\Fractal\Resource\Collection;
+use DateTime;
+
+interface SurveyInterface extends UuidEntityInterface
+{
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_CONFIGURATION = 'configuration';
+    public const STATUS_EVALUATION = 'evaluation';
+    public const STATUS_PARTICIPATION = 'participation';
+
+    public function setId(string $id): void;
+
+    public function getTitle(): string;
+
+    public function setTitle(string $title): void;
+
+    public function getDescription(): string;
+
+    public function setDescription(string $description): void;
+
+    public function getStartDate(): DateTime;
+
+    public function setStartDate(DateTime $startDate): void;
+
+    public function getEndDate(): DateTime;
+
+    public function setEndDate(DateTime $endDate): void;
+
+    public function getStatus(): string;
+
+    public function setStatus(string $status): void;
+
+    public function getProcedure(): ProcedureInterface;
+
+    public function setProcedure(ProcedureInterface $procedure): void;
+
+    public function getVotes(): Collection;
+
+    /**
+     * Returns Survey Vote with given id or null if it doesn't exist.
+     *
+     * @param string $voteId
+     */
+    public function getVote($voteId): ?SurveyVoteInterface;
+
+    public function addVote(SurveyVoteInterface $vote): void;
+
+    public function getPositiveVotes(): Collection;
+
+    public function getNegativeVotes(): Collection;
+
+    public function getReviewRequiredVotes(): Collection;
+}

--- a/src/Contracts/Entities/SurveyInterface.php
+++ b/src/Contracts/Entities/SurveyInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use Doctrine\Common\Collections\Collection;
 use DateTime;
 
-interface SurveyInterface extends UuidEntityInterface
+interface SurveyInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const STATUS_COMPLETED = 'completed';
     public const STATUS_CONFIGURATION = 'configuration';

--- a/src/Contracts/Entities/SurveyInterface.php
+++ b/src/Contracts/Entities/SurveyInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\Collection;
 use DateTime;
 
 interface SurveyInterface extends UuidEntityInterface

--- a/src/Contracts/Entities/SurveyVoteInterface.php
+++ b/src/Contracts/Entities/SurveyVoteInterface.php
@@ -4,7 +4,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
 
-interface SurveyVoteInterface extends UuidEntityInterface
+interface SurveyVoteInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const PUBLICATION_PENDING = 'publication_pending';
     public const PUBLICATION_REJECTED = 'publication_rejected';

--- a/src/Contracts/Entities/SurveyVoteInterface.php
+++ b/src/Contracts/Entities/SurveyVoteInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface SurveyVoteInterface extends UuidEntityInterface
+{
+    public const PUBLICATION_PENDING = 'publication_pending';
+    public const PUBLICATION_REJECTED = 'publication_rejected';
+    public const PUBLICATION_APPROVED = 'publication_approved';
+
+    public function isAgreed(): bool;
+
+    public function getText(): string;
+
+    public function getTextReview(): string;
+
+    public function setTextReview(string $textReview): void;
+
+    /**
+     * Has text and the text is approved.
+     */
+    public function hasApprovedText(): bool;
+
+    /**
+     * A review is required if a) it has not yet happened and b) there is a text to review.
+     */
+    public function isReviewRequired(): bool;
+
+    public function hasText(): bool;
+
+    public function getCreatedDate(): DateTime;
+
+    public function getSurvey(): SurveyInterface;
+
+    public function getUser(): UserInterface;
+
+    public static function getTextReviewAllowedValues(): array;
+}

--- a/src/Contracts/Entities/TagInterface.php
+++ b/src/Contracts/Entities/TagInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
 use DateTime;
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 interface TagInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/TagInterface.php
+++ b/src/Contracts/Entities/TagInterface.php
@@ -4,7 +4,106 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface TagInterface
+use DateTime;
+use League\Fractal\Resource\ArrayCollection;
+
+interface TagInterface extends UuidEntityInterface
 {
+    /**
+     * @param string $id
+     */
+    public function setId($id);
+
+    public function getTopic(): TagTopicInterface;
+
+    /**
+     * @return string
+     */
+    public function getTopicTitle();
+
+    /**
+     * Assign this Tag to a specific TagTopic.
+     * Because a Tag can have one Topic only, it is necessary to remove this Tag from the current Topic (if exists).
+     * Add this Tag to the given Topic and save the information of relation in this object.
+     *
+     * @param TagTopicInterface $newTopic
+     *
+     * @return TagInterface $this
+     */
+    public function setTopic($newTopic);
+
+    /**
+     * @return string
+     */
+    public function getTitle();
+
+    /**
+     * @return string
+     *
+     * @deprecated use {@link getTitle} instead
+     */
+    public function getName();
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedDate();
+
+    /**
+     * @return ProcedureInterface
+     *
+     * @deprecated Only needed for Elasticsearch indexing. Use {@link TagTopicInterface::getProcedure()} instead.
+     */
+    public function getProcedure();
+
+    /**
+     * Add Statement.
+     *
+     * @param StatementInterface $statement
+     *
+     * @return bool - true if the given statement was added to this tag, otherwise false
+     */
+    public function addStatement($statement);
+
+    /**
+     * Sets the boilerplate text that is associated to this tag.
+     *
+     * @param BoilerplateInterface|null $boilerplate
+     */
+    public function setBoilerplate($boilerplate);
+
+    /**
+     * Returns the boilerplate text that is associated with this tag.
+     *
+     * @return BoilerplateInterface|null
+     */
+    public function getBoilerplate();
+
+    /**
+     * Determines if this Tag has a boilerplate.
+     *
+     * @return bool - true there are a boilerplate, otherwise false
+     */
+    public function hasBoilerplate();
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getStatements();
+
+    /**
+     * @param ArrayCollection $statements
+     */
+    public function setStatements($statements);
+
+    /**
+     * @param DateTime $date
+     */
+    public function setCreateDate($date);
 
 }

--- a/src/Contracts/Entities/TagInterface.php
+++ b/src/Contracts/Entities/TagInterface.php
@@ -7,7 +7,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 
-interface TagInterface extends UuidEntityInterface
+interface TagInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * @param string $id

--- a/src/Contracts/Entities/TagTopicInterface.php
+++ b/src/Contracts/Entities/TagTopicInterface.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use League\Fractal\Resource\Collection;
+use DateTime;
+
+interface TagTopicInterface extends UuidEntityInterface
+{
+    public const TAG_TOPIC_MISC = 'Sonstiges';
+
+    /**
+     * @return Collection<int, TagInterface>
+     */
+    public function getTags(): Collection;
+
+    /**
+     * Returns a specific tag of this topic, if exists.
+     *
+     * @param string $id identifies the tag
+     *
+     * @return TagInterface|null
+     */
+    public function getTag($id);
+
+    /**
+     * Add a specific Tag to this Topic.
+     *
+     * @param TagInterface $tag
+     *
+     * @return TagTopicInterface
+     */
+    public function addTag($tag);
+
+    /**
+     * Removes a specific Tag from this Topic.
+     *
+     * @param TagInterface $tag
+     *
+     * @return TagTopicInterface
+     */
+    public function removeTag($tag);
+
+    /**
+     * @param string|null $id
+     */
+    public function setId($id): self;
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedDate();
+
+    /**
+     * @return string
+     */
+    public function getTitle();
+
+    /**
+     * @return string
+     *
+     * @deprecated use {@link getTitle} instead
+     */
+    public function getName();
+
+    /**
+     * Set title.
+     *
+     * @param string $title
+     *
+     * @return string
+     * @return TagTopicInterface
+     */
+    public function setTitle($title);
+
+    /**
+     * @return ProcedureInterface
+     */
+    public function getProcedure();
+
+    /**
+     * @param ProcedureInterface $procedure
+     */
+    public function setProcedure($procedure);
+}

--- a/src/Contracts/Entities/TagTopicInterface.php
+++ b/src/Contracts/Entities/TagTopicInterface.php
@@ -5,7 +5,7 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use Doctrine\Common\Collections\Collection;
 use DateTime;
 
-interface TagTopicInterface extends UuidEntityInterface
+interface TagTopicInterface extends UuidEntityInterface, CoreEntityInterface
 {
     public const TAG_TOPIC_MISC = 'Sonstiges';
 

--- a/src/Contracts/Entities/TagTopicInterface.php
+++ b/src/Contracts/Entities/TagTopicInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-use League\Fractal\Resource\Collection;
+use Doctrine\Common\Collections\Collection;
 use DateTime;
 
 interface TagTopicInterface extends UuidEntityInterface

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -74,9 +74,6 @@ interface UserInterface extends SecurityUserInterface, UuidEntityInterface
      */
     public function getName();
 
-    /**
-     * @deprecated use {@link UserInterface::getId()} instead
-     */
     public function getIdent(): ?string;
 
     /**

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -11,7 +11,7 @@ use Hslavich\OneloginSamlBundle\Security\User\SamlUserInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 
-interface UserInterface extends SecurityUserInterface, UuidEntityInterface, SamlUserInterface, PasswordAuthenticatedUserInterface
+interface UserInterface extends UuidEntityInterface
 {
     /**
      * Set hard coded anonymous user Values until refactored.

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -7,7 +7,7 @@ use DateTimeInterface;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Component\Security\Core\User\UserInterfac as SecurityUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 
 interface UserInterface extends SecurityUserInterface, UuidEntityInterface
 {

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -7,7 +7,9 @@ use DateTimeInterface;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
+use Hslavich\OneloginSamlBundle\Security\User\SamlUserInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 
 interface UserInterface extends UuidEntityInterface, PasswordAuthenticatedUserInterface
 {

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -11,7 +11,7 @@ use Hslavich\OneloginSamlBundle\Security\User\SamlUserInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 
-interface UserInterface extends SecurityUserInterface, UuidEntityInterface, SamlUserInterface, PasswordAuthenticatedUserInterface
+interface UserInterface extends SecurityUserInterface, UuidEntityInterface, SamlUserInterface
 {
     /**
      * Set hard coded anonymous user Values until refactored.

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -2,7 +2,706 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
+use DateTime;
+use DateTimeInterface;
+use DateTimeImmutable;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\ArrayCollection;
+
 interface UserInterface extends UuidEntityInterface
 {
+    /**
+     * Set hard coded anonymous user Values until refactored.
+     */
+    public const ANONYMOUS_USER_DEPARTMENT_ID = '3c77f7b4-3f07-11e4-a6a8-005056ae0004';
+    public const ANONYMOUS_USER_DEPARTMENT_NAME = 'anonym';
+    public const ANONYMOUS_USER_ID = '73830656-3e48-11e4-a6a8-005056ae0004';
+    public const ANONYMOUS_USER_LOGIN = 'anonym@bobsh.de';
+    public const ANONYMOUS_USER_NAME = 'Privatperson';
+    public const ANONYMOUS_USER_ORGA_ID = 'cdec5e4b-3f06-11e4-a6a8-005056ae0004';
+    public const ANONYMOUS_USER_ORGA_NAME = 'Privatperson';
+    public const FHHNET_PREFIX = 'FHHNET\\';
+    public const DEFAULT_ORGA_USER_NAME = 'Institution';
+
+    /**
+     * @param string $id
+     */
+    public function setId($id);
+
+    /**
+     * @return int
+     */
+    public function getDmId();
+
+    /**
+     * @param int $dmId
+     */
+    public function setDmId($dmId);
+
+    /**
+     * @return string
+     */
+    public function getGender();
+
+    /**
+     * @param string $gender
+     */
+    public function setGender($gender);
+
+    /**
+     * @return string
+     */
+    public function getTitle();
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title);
+
+    /**
+     * @return string
+     */
+    public function getFirstname();
+
+    /**
+     * @return string
+     */
+    public function getFullname();
+
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @deprecated use {@link UserInterface::getId()} instead
+     */
+    public function getIdent(): ?string;
+
+    /**
+     * @param string $firstname
+     */
+    public function setFirstname($firstname);
+
+    /**
+     * Get Email.
+     *
+     * @return string
+     */
+    public function getEmail();
+
+    /**
+     * @return string
+     */
+    public function getLastname();
+
+    /**
+     * @param string $lastname
+     */
+    public function setLastname($lastname);
+
+    /**
+     * @param string $email
+     *
+     * @return $this
+     */
+    public function setEmail($email);
+
+    public function getLogin(): ?string;
+
+    public function setLogin(?string $login): void;
+
+    /**
+     * @return string
+     */
+    public function getUsername();
+
+    /**
+     * Symfony > 6 needs getUserIdentifier() for auth system.
+     */
+    public function getUserIdentifier(): ?string;
+
+    public function setPassword(?string $password): void;
+
+    public function getPassword(): ?string;
+
+    /**
+     * @deprecated $this->password should be safe now
+     *
+     * @return string|null
+     */
+    public function getAlternativeLoginPassword();
+
+    public function setAlternativeLoginPassword(?string $alternativeLoginPassword);
+
+    /**
+     * Returns the salt that was originally used to encode the password.
+     *
+     * This can return null if the password was not encoded using a salt.
+     */
+    public function getSalt(): ?string;
+
+    public function setSalt(?string $salt): UserInterface;
+
+    /**
+     * @return string
+     */
+    public function getLanguage();
+
+    /**
+     * @param string $language
+     */
+    public function setLanguage($language);
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedDate();
+
+    /**
+     * @param DateTime $createdDate
+     */
+    public function setCreatedDate(DateTime $createdDate);
+
+    /**
+     * @return DateTime
+     */
+    public function getModifiedDate();
+
+    /**
+     * @param DateTime $modifiedDate
+     */
+    public function setModifiedDate(DateTimeInterface $modifiedDate);
+
+    /**
+     * @param DateTime|DateTimeImmutable $lastLogin
+     */
+    public function setLastLogin(DateTimeInterface $lastLogin): void;
+
+    /**
+     * @return DateTime|DateTimeImmutable|null
+     */
+    public function getLastLogin(): ?DateTimeInterface;
+
+    /**
+     * @return bool
+     */
+    public function isDeleted();
+
+    /**
+     * @param bool $deleted
+     */
+    public function setDeleted($deleted);
+
+    /**
+     * @return string
+     */
+    public function getGwId();
+
+    /**
+     * @param string $gwId
+     */
+    public function setGwId($gwId);
+
+    /**
+     * Ist das Passwort noch als md5 gespeichert?
+     */
+    public function isLegacy(): bool;
+
+    /**
+     * @return array
+     */
+    public function getFlags();
+
+    /**
+     * Do not use Matomo. Should be $useMatomo.
+     */
+    public function getNoPiwik(): bool;
+
+    /**
+     * @param bool $noPiwik
+     */
+    public function setNoPiwik($noPiwik);
+
+    public function getAssignedTaskNotification(): bool;
+
+    public function setAssignedTaskNotification(bool $assignedTaskNotification);
+
+    public function getNewsletter(): bool;
+
+    /**
+     * @param bool $newsletter
+     */
+    public function setNewsletter($newsletter);
+
+    public function isNewUser(): bool;
+
+    /**
+     * @param bool $newUser
+     */
+    public function setNewUser($newUser);
+
+    public function isIntranet(): bool;
+
+    /**
+     * @param bool $intranet
+     */
+    public function setIntranet($intranet);
+
+    public function isProfileCompleted(): bool;
+
+    /**
+     * @param bool $profileCompleted
+     */
+    public function setProfileCompleted($profileCompleted);
+
+    /**
+     * Is the user Guest or Citizen?
+     */
+    public function isPublicUser(): bool;
+
+    /**
+     * Is the user Guest only?
+     */
+    public function isGuestOnly(): bool;
+
+    public function isPlanner(): bool;
+
+    public function isHearingAuthority(): bool;
+
+    /**
+     * Role::ORGANISATION_ADMINISTRATION is not included.
+     */
+    public function isProcedureAdmin(): bool;
+
+    public function isPlanningAgency(): bool;
+
+    public function isPublicAgency(): bool;
+
+    /**
+     * Is the user Citizen?
+     */
+    public function isCitizen(): bool;
+
+    public function getForumNotification(): bool;
+
+    /**
+     * @param bool $forumNotification
+     */
+    public function setForumNotification($forumNotification);
+
+    public function isAccessConfirmed(): bool;
+
+    /**
+     * @param bool $accessConfirmed
+     */
+    public function setAccessConfirmed($accessConfirmed);
+
+    public function isInvited(): bool;
+
+    /**
+     * @param bool $invited
+     */
+    public function setInvited($invited);
+
+    /**
+     * Add arbitrary UserFlag.
+     *
+     * @param string $key
+     * @param bool   $value
+     */
+    public function addFlag($key, $value);
+
+    /**
+     * Return arbitrary UserFlag.
+     *
+     * @param string $key
+     */
+    public function getFlag($key): bool;
+
+    public function addAuthorizedProcedure(ProcedureInterface $procedure): bool;
+
+    /**
+     * @return Collection<int, ProcedureInterface>
+     */
+    public function getAuthorizedProcedures(): Collection;
+
+    /**
+     * Organisation des Users.
+     */
+    public function getOrga(): ?OrgaInterface;
+
+    /**
+     * Returns the Id of the organisation where this user belongs to, if exists, otherwise null.
+     *
+     * @return string|null
+     */
+    public function getOrganisationId();
+
+    /**
+     * Returns the name of the organisation where this user belongs to, if exists, otherwise null.
+     *
+     * @return string|null
+     */
+    public function getOrgaName();
+
+    /**
+     * Legacyfunction to provide OrgaName to be safer on refactoring.
+     */
+    public function getOrganisationNameLegal(): ?string;
+
+    /**
+     * Organisation des Users hinzufügen.
+     */
+    public function setOrga(OrgaInterface $orga);
+
+    /**
+     * Organisation des Users entfernen.
+     */
+    public function unsetOrgas();
+
+    /**
+     * Department des Users.
+     *
+     * @return DepartmentInterface|null
+     */
+    public function getDepartment();
+
+    public function getDepartmentId(): string;
+
+    /**
+     * Legacyfunction to provide DepartmentName to be safer on refactoring.
+     *
+     * @return string
+     */
+    public function getDepartmentNameLegal();
+
+    public function getDepartmentName(): string;
+
+    /**
+     * Department des Users.
+     *
+     * @return Collection<int, DepartmentInterface>
+     */
+    public function getDepartments();
+
+    /**
+     * Add Department to User.
+     */
+    public function addDepartment(DepartmentInterface $department);
+
+    /**
+     * Replace a Department of User.
+     */
+    public function setDepartment(DepartmentInterface $department);
+
+    /**
+     * Remove Department from User.
+     */
+    public function removeDepartment(DepartmentInterface $department);
+
+    /**
+     * Unset Department.
+     */
+    public function unsetDepartment();
+
+    public function getAddress(): ?AddressInterface;
+
+    /**
+     * @return Collection<int, AddressInterface>
+     */
+    public function getAddresses();
+
+    /**
+     * @param array $addresses
+     *
+     * @return $this
+     */
+    public function setAddresses($addresses);
+
+    /**
+     * Add Address to User.
+     *
+     * @param AddressInterface $address
+     */
+    public function addAddress($address);
+
+    /**
+     * Get Postalcode from associated (first) {@link AddressInterface}.
+     */
+    public function getPostalcode(): string;
+
+    /**
+     * @param string $postalcode
+     *
+     * @return $this
+     */
+    public function setPostalcode($postalcode);
+
+    /**
+     * Get City from associated (first) {@link AddressInterface}.
+     */
+    public function getCity(): string;
+
+    /**
+     * @param string $city
+     *
+     * @return $this
+     */
+    public function setCity($city);
+
+    /**
+     * Get Street from associated (first) {@link AddressInterface}.
+     */
+    public function getStreet(): string;
+
+    /**
+     * Get Housenumber from associated (first) {@link AddressInterface}.
+     */
+    public function getHouseNumber(): string;
+
+    /**
+     * @return $this
+     */
+    public function setHouseNumber(string $houseNumber);
+
+    /**
+     * @param string $street
+     *
+     * @return $this
+     */
+    public function setStreet($street);
+
+    /**
+     * Get State from associated (first) {@link AddressInterface}.
+     */
+    public function getState(): ?string;
+
+    /**
+     * @param string $state
+     *
+     * @return $this
+     */
+    public function setState($state);
+
+    /**
+     * Save single Value in associated Address.
+     *
+     * @param string $key
+     * @param string $value
+     */
+    public function setAddressValue($key, $value);
+
+    /**
+     * @param array<int, string> $roles
+     */
+    public function setRolesAllowed($roles): void;
+
+    public function getTwinUser(): ?UserInterface;
+
+    public function hasTwinUser(): bool;
+
+    public function setTwinUser(?UserInterface $twinUser): UserInterface;
+
+    /**
+     * Returns collection of roles the user has with a specified customer (current is default).
+     *
+     * @return Collection<int, RoleInterface>
+     */
+    public function getDplanroles(CustomerInterface $customer = null): Collection;
+
+    /**
+     * Returns an array of the code of roles the user has with a specified customer (current is default).
+     *
+     * @return string[]
+     */
+    public function getDplanRolesArray(CustomerInterface $customer = null): array;
+
+    /**
+     * This function is needed to clear the roles cache to prevent roles being still present
+     * after they have been actually removed.
+     */
+    public function clearRolesCache(): void;
+
+    /**
+     * @return string[]
+     */
+    public function getDplanRoleGroupsArray();
+
+    /**
+     * Alias for getDplanRoleGroupsArray, used e.g. in twig.
+     *
+     * @return string[]
+     */
+    public function getRoleGroups();
+
+    /**
+     * @return string|null
+     */
+    public function getDplanRolesString();
+
+    /**
+     * @return string|null
+     */
+    public function getDplanRolesGroupString();
+
+    /**
+     * Sets Roles. Note that, in order to do this, {@link UserRoleInCustomerInterface} objects are created which have a role and
+     * the current customer.
+     *
+     * @see https://yaits.demos-deutschland.de/w/demosplan/functions/permissions/ Wiki: Permissions, Roles, etc.
+     *
+     * @param RoleInterface[]        $roles
+     * @param CustomerInterface|null $customer
+     */
+    public function setDplanroles(array $roles, $customer = null): void;
+
+    /**
+     * @param Collection<int,UserRoleInCustomerInterface> $roleInCustomers
+     */
+    public function setRoleInCustomers(Collection $roleInCustomers): void;
+
+    /**
+     * @param CustomerInterface|null $customer
+     */
+    public function addDplanrole(RoleInterface $role, $customer = null);
+
+    /**
+     * Check whether user has role (code) with a specified customer (current is default).
+     *
+     * @param string $role
+     */
+    public function hasRole($role, CustomerInterface $customer = null): bool;
+
+    public function hasAnyOfRoles(array $roles): bool;
+
+    /**
+     * Returns the roles granted to the user.
+     *
+     * <code>
+     * public function getRoles()
+     * {
+     *     return array('ROLE_USER');
+     * }
+     * </code>
+     *
+     * Alternatively, the roles might be stored on a ``roles`` property,
+     * and populated in any number of different ways when the user object
+     * is created.
+     *
+     * @return string[] The user roles
+     */
+    public function getRoles(): array;
+
+    /**
+     * Alias for getDplanRolesString.
+     *
+     * @return string
+     */
+    public function getRole();
+
+    /**
+     * Setzen des loggedIn Status auf true.
+     */
+    public function isLoggedIn(): bool;
+
+    /**
+     * We cannot remove any sensitive data from user object during login (this is where this is called)
+     * as user object is persisted later on which would lead in an empty password field in database.
+     */
+    public function eraseCredentials(): void;
+
+    public function getEntityContentChangeIdentifier(): string;
+
+    public function getDraftStatementSubmissionReminderEnabled(): bool;
+
+    public function setDraftStatementSubmissionReminderEnabled(bool $draftStatementSubmissionReminderEnabled);
+
+    /**
+     * Retrieve all customers that the user is associated with in any way.
+     *
+     * @return array<int, CustomerInterface>
+     */
+    public function getCustomers(): array;
+
+    /**
+     * Retrieve all customers that the user is associated with directly. This is only the case for customer users.
+     *
+     * @see https://yaits.demos-deutschland.de/w/demosplan/functions/permissions/ wiki: customer role user orga logic
+     */
+    public function getCustomersForCustomerUsers(): array;
+
+    /**
+     * Retrieve all customers that the user is associated with through an orga.
+     *
+     * @see https://yaits.demos-deutschland.de/w/demosplan/functions/permissions/ wiki: customer role user orga logic
+     *
+     * @param array $orgaType Per default, all are returned. Array of orgaType constants.
+     */
+    public function getCustomersForUsersOfOrganisationsOfType(array $orgaType = [OrgaTypeInterface::MUNICIPALITY, OrgaTypeInterface::PLANNING_AGENCY, OrgaTypeInterface::PUBLIC_AGENCY]): array;
+
+    /**
+     * The user has an organization that, in its role as "Kommmune", can only have one customer. Get that customer.
+     *
+     * @see https://yaits.demos-deutschland.de/w/demosplan/functions/permissions/ wiki: customer role user orga logic
+     *
+     * @return CustomerInterface|null
+     */
+    public function getCustomersForUsersOfOrganisationsOfTypeKommune();
+
+    /**
+     * Returns an array of Customer ids.
+     */
+    public function getCustomersIds(): array;
+
+    /**
+     * @return Collection<int,UserRoleInCustomerInterface>
+     */
+    public function getRoleInCustomers(): Collection;
+
+    /**
+     * May be null e.g. during user add.
+     */
+    public function getCurrentCustomer(): ?CustomerInterface;
+
+    public function setCurrentCustomer(CustomerInterface $currentCustomer): void;
+
+    /**
+     * Given a subdomain returns the role that current user plays there.
+     * If user doesn't belong to subdomain, then empty string is returned.
+     *
+     * @return string
+     */
+    public function getRoleBySubdomain(string $subdomain);
+
+    /**
+     * @return Collection<int, SurveyVoteInterface>
+     */
+    public function getSurveyVotes(): Collection;
+
+    /**
+     * Returns SurveyVote with the given id or null if none exists.
+     *
+     * @param string $surveyVoteId
+     */
+    public function getSurveyVote($surveyVoteId): ?SurveyVoteInterface;
+
+    public function addSurveyVote(SurveyVoteInterface $surveyVote): void;
+
+    /**
+     * Should be indexed in Elasticsearch.
+     */
+    public function shouldBeIndexed(): bool;
+
+    /**
+     * This method will be used to fill user properties from saml providers.
+     */
+    public function setSamlAttributes(array $attributes): void;
+
+    public function isDefaultGuestUser(): bool;
+
+    public function isProvidedByIdentityProvider(): bool;
+
+    public function setProvidedByIdentityProvider(bool $providedByIdentityProvider): void;
 
 }

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -11,7 +11,7 @@ use Hslavich\OneloginSamlBundle\Security\User\SamlUserInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 
-interface UserInterface extends SecurityUserInterface, UuidEntityInterface, SamlUserInterface
+interface UserInterface extends SecurityUserInterface, UuidEntityInterface, SamlUserInterface, PasswordAuthenticatedUserInterface
 {
     /**
      * Set hard coded anonymous user Values until refactored.

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -5,8 +5,8 @@ namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 use DateTime;
 use DateTimeInterface;
 use DateTimeImmutable;
-use League\Fractal\Resource\Collection;
-use League\Fractal\Resource\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 interface UserInterface extends UuidEntityInterface
 {

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -128,7 +128,7 @@ interface UserInterface extends SecurityUserInterface, UuidEntityInterface
 
     public function setAlternativeLoginPassword(?string $alternativeLoginPassword);
 
-    public function setSalt(?string $salt): UserInterface;
+    public function setSalt(?string $salt): SecurityUserInterface;
 
     /**
      * @return string
@@ -484,11 +484,11 @@ interface UserInterface extends SecurityUserInterface, UuidEntityInterface
      */
     public function setRolesAllowed($roles): void;
 
-    public function getTwinUser(): ?UserInterface;
+    public function getTwinUser(): ?SecurityUserInterface;
 
     public function hasTwinUser(): bool;
 
-    public function setTwinUser(?UserInterface $twinUser): UserInterface;
+    public function setTwinUser(?UserInterface $twinUser): SecurityUserInterface;
 
     /**
      * Returns collection of roles the user has with a specified customer (current is default).

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -7,8 +7,9 @@ use DateTimeInterface;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\Security\Core\User\UserInterfac as SecurityUserInterface;
 
-interface UserInterface extends UuidEntityInterface
+interface UserInterface extends SecurityUserInterface, UuidEntityInterface
 {
     /**
      * Set hard coded anonymous user Values until refactored.
@@ -112,18 +113,11 @@ interface UserInterface extends UuidEntityInterface
     public function setLogin(?string $login): void;
 
     /**
-     * @return string
-     */
-    public function getUsername();
-
-    /**
      * Symfony > 6 needs getUserIdentifier() for auth system.
      */
     public function getUserIdentifier(): ?string;
 
     public function setPassword(?string $password): void;
-
-    public function getPassword(): ?string;
 
     /**
      * @deprecated $this->password should be safe now
@@ -133,13 +127,6 @@ interface UserInterface extends UuidEntityInterface
     public function getAlternativeLoginPassword();
 
     public function setAlternativeLoginPassword(?string $alternativeLoginPassword);
-
-    /**
-     * Returns the salt that was originally used to encode the password.
-     *
-     * This can return null if the password was not encoded using a salt.
-     */
-    public function getSalt(): ?string;
 
     public function setSalt(?string $salt): UserInterface;
 
@@ -576,24 +563,6 @@ interface UserInterface extends UuidEntityInterface
     public function hasAnyOfRoles(array $roles): bool;
 
     /**
-     * Returns the roles granted to the user.
-     *
-     * <code>
-     * public function getRoles()
-     * {
-     *     return array('ROLE_USER');
-     * }
-     * </code>
-     *
-     * Alternatively, the roles might be stored on a ``roles`` property,
-     * and populated in any number of different ways when the user object
-     * is created.
-     *
-     * @return string[] The user roles
-     */
-    public function getRoles(): array;
-
-    /**
      * Alias for getDplanRolesString.
      *
      * @return string
@@ -604,12 +573,6 @@ interface UserInterface extends UuidEntityInterface
      * Setzen des loggedIn Status auf true.
      */
     public function isLoggedIn(): bool;
-
-    /**
-     * We cannot remove any sensitive data from user object during login (this is where this is called)
-     * as user object is persisted later on which would lead in an empty password field in database.
-     */
-    public function eraseCredentials(): void;
 
     public function getEntityContentChangeIdentifier(): string;
 

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -11,7 +11,7 @@ use Hslavich\OneloginSamlBundle\Security\User\SamlUserInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 
-interface UserInterface extends UuidEntityInterface
+interface UserInterface extends UuidEntityInterface, PasswordAuthenticatedUserInterface
 {
     /**
      * Set hard coded anonymous user Values until refactored.

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -76,8 +76,6 @@ interface UserInterface extends UuidEntityInterface, PasswordAuthenticatedUserIn
      */
     public function getName();
 
-    public function getIdent(): ?string;
-
     /**
      * @param string $firstname
      */
@@ -110,6 +108,44 @@ interface UserInterface extends UuidEntityInterface, PasswordAuthenticatedUserIn
     public function getLogin(): ?string;
 
     public function setLogin(?string $login): void;
+
+    /**
+     * @return string
+     */
+    public function getUsername();
+
+    /**
+     * Returns the roles granted to the user.
+     *
+     * <code>
+     * public function getRoles()
+     * {
+     *     return array('ROLE_USER');
+     * }
+     * </code>
+     *
+     * Alternatively, the roles might be stored on a ``roles`` property,
+     * and populated in any number of different ways when the user object
+     * is created.
+     *
+     * @return string[] The user roles
+     */
+    public function getRoles(): array;
+
+    public function getPassword(): ?string;
+
+    /**
+     * Returns the salt that was originally used to encode the password.
+     *
+     * This can return null if the password was not encoded using a salt.
+     */
+    public function getSalt(): ?string;
+
+    /**
+     * We cannot remove any sensitive data from user object during login (this is where this is called)
+     * as user object is persisted later on which would lead in an empty password field in database.
+     */
+    public function eraseCredentials(): void;
 
     /**
      * Symfony > 6 needs getUserIdentifier() for auth system.
@@ -147,7 +183,7 @@ interface UserInterface extends UuidEntityInterface, PasswordAuthenticatedUserIn
     /**
      * @param DateTime $createdDate
      */
-    public function setCreatedDate(DateTime $createdDate);
+    public function setCreatedDate(DateTimeInterface $createdDate);
 
     /**
      * @return DateTime

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -7,9 +7,7 @@ use DateTimeInterface;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
-use Hslavich\OneloginSamlBundle\Security\User\SamlUserInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
-use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 
 interface UserInterface extends UuidEntityInterface, PasswordAuthenticatedUserInterface
 {

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -7,9 +7,11 @@ use DateTimeInterface;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
+use Hslavich\OneloginSamlBundle\Security\User\SamlUserInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 
-interface UserInterface extends SecurityUserInterface, UuidEntityInterface
+interface UserInterface extends SecurityUserInterface, UuidEntityInterface, SamlUserInterface, PasswordAuthenticatedUserInterface
 {
     /**
      * Set hard coded anonymous user Values until refactored.
@@ -652,11 +654,6 @@ interface UserInterface extends SecurityUserInterface, UuidEntityInterface
      * Should be indexed in Elasticsearch.
      */
     public function shouldBeIndexed(): bool;
-
-    /**
-     * This method will be used to fill user properties from saml providers.
-     */
-    public function setSamlAttributes(array $attributes): void;
 
     public function isDefaultGuestUser(): bool;
 

--- a/src/Contracts/Entities/UserRoleInCustomerInterface.php
+++ b/src/Contracts/Entities/UserRoleInCustomerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+interface UserRoleInCustomerInterface extends UuidEntityInterface
+{
+    /**
+     * Set User.
+     */
+    public function setUser(UserInterface $user): self;
+
+    /**
+     * Get User.
+     */
+    public function getUser(): UserInterface;
+
+    /**
+     * Set Role.
+     */
+    public function setRole(RoleInterface $role): self;
+
+    /**
+     * Get Role.
+     */
+    public function getRole(): RoleInterface;
+
+    public function setCustomer(?CustomerInterface $customer): self;
+
+    /**
+     * Get Customer.
+     *
+     * @return CustomerInterface|null
+     */
+    public function getCustomer();
+
+}

--- a/src/Contracts/Entities/UserRoleInCustomerInterface.php
+++ b/src/Contracts/Entities/UserRoleInCustomerInterface.php
@@ -2,7 +2,7 @@
 
 namespace DemosEurope\DemosplanAddon\Contracts\Entities;
 
-interface UserRoleInCustomerInterface extends UuidEntityInterface
+interface UserRoleInCustomerInterface extends UuidEntityInterface, CoreEntityInterface
 {
     /**
      * Set User.

--- a/src/Contracts/Entities/VideoInterface.php
+++ b/src/Contracts/Entities/VideoInterface.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTimeInterface;
+
+interface VideoInterface extends UuidEntityInterface
+{
+    /**
+     * Taken from [iana](https://www.iana.org/assignments/media-types/media-types.xhtml#video).
+     */
+    public const VALID_MIME_TYPES = [
+        'video/1d-interleaved-parityfec',
+        'video/3gpp',
+        'video/3gpp2',
+        'video/3gpp-tt',
+        'video/AV1',
+        'video/BMPEG',
+        'video/BT656',
+        'video/CelB',
+        'video/DV',
+        'video/encaprtp',
+        'video/example',
+        'video/FFV1',
+        'video/flexfec',
+        'video/H261',
+        'video/H263',
+        'video/H263-1998',
+        'video/H263-2000',
+        'video/H264',
+        'video/H264-RCDO',
+        'video/H264-SVC',
+        'video/H265',
+        'video/iso.segment',
+        'video/JPEG',
+        'video/jpeg2000',
+        'video/jxsv',
+        'video/mj2',
+        'video/MP1S',
+        'video/MP2P',
+        'video/MP2T',
+        'video/mp4',
+        'video/MP4V-ES',
+        'video/MPV',
+        'video/mpeg4-generic',
+        'video/nv',
+        'video/ogg',
+        'video/parityfec',
+        'video/pointer',
+        'video/quicktime',
+        'video/raptorfec',
+        'video/raw',
+        'video/rtp-enc-aescm128',
+        'video/rtploopback',
+        'video/rtx',
+        'video/scip',
+        'video/smpte291',
+        'video/SMPTE292M',
+        'video/ulpfec',
+        'video/vc1',
+        'video/vc2',
+        'video/vnd.CCTV',
+        'video/vnd.dece.hd',
+        'video/vnd.dece.mobile',
+        'video/vnd.dece.mp4',
+        'video/vnd.dece.pd',
+        'video/vnd.dece.sd',
+        'video/vnd.dece.video',
+        'video/vnd.directv.mpeg',
+        'video/vnd.directv.mpeg-tts',
+        'video/vnd.dlna.mpeg-tts',
+        'video/vnd.dvb.file',
+        'video/vnd.fvt',
+        'video/vnd.hns.video',
+        'video/vnd.iptvforum.1dparityfec-1010',
+        'video/vnd.iptvforum.1dparityfec-2005',
+        'video/vnd.iptvforum.2dparityfec-1010',
+        'video/vnd.iptvforum.2dparityfec-2005',
+        'video/vnd.iptvforum.ttsavc',
+        'video/vnd.iptvforum.ttsmpeg2',
+        'video/vnd.motorola.video',
+        'video/vnd.motorola.videop',
+        'video/vnd.mpegurl',
+        'video/vnd.ms-playready.media.pyv',
+        'video/vnd.nokia.interleaved-multimedia',
+        'video/vnd.nokia.mp4vr',
+        'video/vnd.nokia.videovoip',
+        'video/vnd.objectvideo',
+        'video/vnd.radgamettools.bink',
+        'video/vnd.radgamettools.smacker',
+        'video/vnd.sealed.mpeg1',
+        'video/vnd.sealed.mpeg4',
+        'video/vnd.sealed.swf',
+        'video/vnd.sealedmedia.softseal.mov',
+        'video/vnd.uvvu.mp4',
+        'video/vnd.youtube.yt',
+        'video/vnd.vivo',
+        'video/VP8',
+        'video/VP9',
+    ];
+    public function getUploader(): ?UserInterface;
+
+    public function getCustomerContext(): CustomerInterface;
+
+    public function getFile(): FileInterface;
+
+    public function getTitle(): string;
+
+    public function setTitle(string $title): self;
+
+    public function getDescription(): string;
+
+    public function setDescription(string $description): self;
+
+    public function getCreationDate(): ?DateTimeInterface;
+
+    public function getModificationDate(): ?DateTimeInterface;
+}


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32212

Description:
add methods to interfaces / add new necessary interfaces...

the CoreEntityInterface now requires the method getEntityContentChangeIdentifier() which is not implemented by all entities inside addons. This has to be changed. - done in https://github.com/demos-europe/demosplan-addon-demospipes/pull/70


I did not finish the whole thing, but everything should be in a valid state at this point.

### Linked PRs (optional)
 - this PR is dependent on https://github.com/demos-europe/demosplan-core/pull/1378 and needs to be merged together.
 - this PR is dependent on https://github.com/demos-europe/demosplan-addon/pull/53
 - this PR is in the attachment with https://github.com/demos-europe/demosplan-core/pull/1254 in Core and 
 - this PR is in the attachment with https://github.com/demos-europe/demosplan-addon-demospipes/pull/70 in Addon
###

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly