### PR TITLE
chore: move method to correct interface

### DIFF
--- a/src/Contracts/Services/MapServiceStorageInterface.php
+++ b/src/Contracts/Services/MapServiceStorageInterface.php
@@ -4,17 +4,7 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Services;
 
-use Exception;
-
 interface MapServiceStorageInterface
 {
-    /**
-     * @param array  $data
-     * @param string $procedureID
-     *
-     * @return array
-     *
-     * @throws Exception
-     */
-    public function administrationGlobalGisHandler($data, $procedureID);
+
 }

--- a/src/Contracts/Services/ProcedureServiceStorageInterface.php
+++ b/src/Contracts/Services/ProcedureServiceStorageInterface.php
@@ -5,8 +5,18 @@ declare(strict_types=1);
 namespace DemosEurope\DemosplanAddon\Contracts\Services;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use Exception;
 
 interface ProcedureServiceStorageInterface
 {
     public function administrationNewHandler(array $data, string $currentUserId): ProcedureInterface;
+    /**
+     * @param array  $data
+     * @param string $procedureID
+     *
+     * @return array
+     *
+     * @throws Exception
+     */
+    public function administrationGlobalGisHandler($data, $procedureID);
 }


### PR DESCRIPTION
During a former split of an Interface into two interfaces the method `administrationGlobalGisHandler` was added to the wrong new interface.