### PR TITLE
chore: remove method that is not needed in Customer

### DIFF
--- a/src/Contracts/Entities/CustomerInterface.php
+++ b/src/Contracts/Entities/CustomerInterface.php
@@ -41,11 +41,6 @@ interface CustomerInterface extends UuidEntityInterface, CoreEntityInterface
     public function getOrgas(): Collection;
 
     /**
-     * @return string[]
-     */
-    public function getEmailsOfUsersOfOrgas(): array;
-
-    /**
      * @param Collection<int, OrgaInterface> $orgas
      */
     public function setOrgas(Collection $orgas);


### PR DESCRIPTION
`getEmailsOfUsersOfOrgas` should not be used in Customer entity as we want dumb entities and no active record