### PR TITLE
chore: add getProjectCoreVersion to interface

### DIFF
--- a/src/Contracts/Config/GlobalConfigInterface.php
+++ b/src/Contracts/Config/GlobalConfigInterface.php
@@ -199,6 +199,8 @@ interface GlobalConfigInterface
      */
     public function getProxyPort(): string;
 
+    public function getProjectCoreVersion(): string;
+
     public function getProjectVersion(): string;
 
     public function getProjectShortUrlRedirectRoute(): string;


### PR DESCRIPTION
A new Method getProjectCoreVersion is needed to reflect the core version that is used by a project