### PR TITLE
feat (T32776): Adjustments to PostProcedureUpdatedEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## UNRELEASED
 
+## v0.6 (2023-07-19)
+
+- **feat** Adjusted the PostProcedureUpdatedEventInterface.
+- PostProcedureUpdateEvent::getProcedure() was removed.
+- PostProcedureUpdatedEvent::getProcedureBeforeUpdate() was added.
+- PostProcedureUpdatedEvent::getProcedureAfterUpdate() was added.
+- PostProcedureUpdatedEvent::getModifiedValues() was added.
+
 ## v0.5 (2023-07-13)
 
 - add interface needed for xBeteiligungAsyncAddon

--- a/src/Contracts/Events/PostProcedureUpdatedEventInterface.php
+++ b/src/Contracts/Events/PostProcedureUpdatedEventInterface.php
@@ -9,5 +9,7 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 
 interface PostProcedureUpdatedEventInterface
 {
-    public function getProcedure(): ProcedureInterface;
+    public function getProcedureBeforeUpdate(): ProcedureInterface;
+    public function getProcedureAfterUpdate(): ProcedureInterface;
+    public function getModifiedValues(): array;
 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32776

This PR adjusts the corresponding interface of PostProcedureUpdatedEvent.

PR in core: https://github.com/demos-europe/demosplan-core/pull/1741
Commit with relevant changes in xBeteiligung addon: https://github.com/demos-europe/demosplan-addon-xbeteiligung-async/pull/4/commits/edd146ebf3643a8925804341a6db6b5d833c4cde