### PR TITLE
chore: remove GlobalConfigInterface::subdomainsAllowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- remove GlobalConfigInterface::subdomainsAllowed
+
 ## v0.8 (2023-08-23)
 
 - add interface needed for SegmentOracle

--- a/src/Contracts/Config/GlobalConfigInterface.php
+++ b/src/Contracts/Config/GlobalConfigInterface.php
@@ -374,13 +374,6 @@ interface GlobalConfigInterface
 
     public function setSubdomain(string $subdomain): void;
 
-    /**
-     * Defines which subdomains (aka {@link CustomerInterface}s) are allowed.
-     *
-     * @return array<int,string>
-     */
-    public function getSubdomainsAllowed(): array;
-
     public function getOrgaBrandedRoutes(): array;
 
     public function getPublicIndexRoute(): string;


### PR DESCRIPTION
GlobalConfigInterface::subdomainsAllowed is not used any more as the concept behind is too static

https://github.com/demos-europe/demosplan-core/pull/1990