### PR TITLE
chore: improve api error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## UNRELEASED
+
+- improve api error logging
+
 ## v0.16 (2024-01-10)
 - technical release as v0.15 failed in release process
 

--- a/src/Controller/APIController.php
+++ b/src/Controller/APIController.php
@@ -210,7 +210,7 @@ abstract class APIController extends AbstractController
         $status = Response::HTTP_BAD_REQUEST;
         $message = '';
 
-        $this->logger->error('API exception occurred', [$exception]);
+        $this->logger->error('API exception occurred', ['exception' => $exception, 'backtrace' => debug_backtrace()]);
 
         try {
             $exceptionParentInterfaces = class_implements(get_class($exception));


### PR DESCRIPTION
This PR adds a backtrace to an api error to get a clue where the Exception happened