### PR TITLE
f remove unnecessary definitions from services yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- remove unnecessary definitions from services yaml
+
 ## v0.22 (2024-01-29)
 
 - adjust ProcedureInterface due to method-declaration-changes.

--- a/config/services.yml
+++ b/config/services.yml
@@ -14,9 +14,3 @@ services:
   DemosEurope\DemosplanAddon\Controller\APIController:
     arguments:
       $resourceTypeProvider: '@demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider'
-
-  DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface:
-    class: 'demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig'
-    public: true
-
-  DemosEurope\DemosplanAddon\Permission\PermissionEvaluatorInterface: '@demosplan\DemosPlanCoreBundle\Permissions\Permissions'


### PR DESCRIPTION
Description: remove definitions with namespaces from Core from services yaml. These defintions are not needed anyway ( the definitions are already in core ), otherwise is not allowed anyway to use them here.

- the 'GlobalConfigInterface' exist already in core services yaml.
- the 'PermissionEvaluatorInterface' exist already in every projects config yaml