### PR TITLE
chore: fix user interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## UNRELEASED
+- fix user interface
 
 ## v0.24 (2024-02-02)
 - technical release to heal release problem in previous version

--- a/src/Contracts/CurrentUserInterface.php
+++ b/src/Contracts/CurrentUserInterface.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DemosEurope\DemosplanAddon\Contracts;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 interface CurrentUserInterface
 {


### PR DESCRIPTION
CurrentUserInterface should return dplan UserInterface that extends Symfony UserInterface