### PR TITLE
feature (refs ADO_2024.8.0) prepare DocxAddonImporterInterface

### DIFF
--- a/src/Contracts/Tools/DocxAddonImporterInterface.php
+++ b/src/Contracts/Tools/DocxAddonImporterInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DemosEurope\DemosplanAddon\Contracts\Tools;
+
+use Symfony\Component\HttpFoundation\File\File;
+
+interface DocxAddonImporterInterface
+{
+    public function importDocx(File $file, string $procedureId): array;
+}


### PR DESCRIPTION
Ticket: 
https://www.dev.diplanung.de/DefaultCollection/BOP-HH/_workitems/edit/16632

Description:
In order to use the existing DocxToHtml importer in addons we need this interface.