### PR TITLE
feat (DPLAN-3268): Add type declaration to StatementInterface::getUserName()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## UNRELEASED
+- Add type declaration to StatementInterface::getUserName()
+
 ## v0.36 (2024-06-12)
 - update deprecated Tightenco\Collect to Illuminate\Support\Collection
 

--- a/src/Contracts/Entities/StatementInterface.php
+++ b/src/Contracts/Entities/StatementInterface.php
@@ -193,10 +193,8 @@ interface StatementInterface extends UuidEntityInterface, CoreEntityInterface
 
     /**
      * Returns the name of the author!
-     *
-     * @return string
      */
-    public function getUserName();
+    public function getUserName(): ?string;
 
     /**
      * Set oId.


### PR DESCRIPTION
Adjusts return type declaration for the getUserName() method of StatementInterface.

See: https://github.com/demos-europe/demosplan-core/pull/3339