### PR TITLE
feature (refs DPLAN_11803) add constant to procedure holding default non participation state : configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## UNRELEASED
+
+## v0.35.1 (2024-07-01)
+- add constant to ProcedureInterface signaling a non participating-state
+
 ## v0.35 (2024-05-21)
 - add methods to SingleDocumentHandlerInterface
 - add interface for new event StatementPreDeleteEventInterface

--- a/composer.json
+++ b/composer.json
@@ -61,5 +61,5 @@
   "scripts": {
     "phpstan": "phpstan analyse"
   },
-  "version": "v0.35"
+  "version": "v0.35.1"
 }

--- a/src/Contracts/Entities/ProcedureInterface.php
+++ b/src/Contracts/Entities/ProcedureInterface.php
@@ -35,6 +35,13 @@ interface ProcedureInterface extends SluggedEntityInterface
     public const PARTICIPATIONSTATE_FINISHED = 'finished';
 
     /**
+     * Value to define the default procedure non participation state.
+     *
+     * @var string
+     */
+    public const PARTICIPATIONSTATE_CONFIGURATION = 'configuration';
+
+    /**
      * Value to define that users may provide an access token to participate.
      *
      * @value string


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-11803/Munchen-Prod-Fehlender-Hinweis-bzgl.-Umstellung-Institutionsverfahren-in-Auswertung

Description:
Blp needs this one on v0.35
We need this value to determine the appropriate text... regarding phase changes of procedures