### PR TITLE
feature (refs DPLAN-1917) Move customer constants into CustomerInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## UNRELEASED
+- Add default Map setting values to the CustomerInterface
+- Move Customer constants into the CustomerInterface
 
 ## v0.38 (2024-07-18)
 - Add getter and setter to placeinterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## UNRELEASED
+
+## v0.39 (2024-09-20)
 - Add default Map setting values to the CustomerInterface
 - Move Customer constants into the CustomerInterface
 

--- a/composer.json
+++ b/composer.json
@@ -61,5 +61,5 @@
   "scripts": {
     "phpstan": "phpstan analyse"
   },
-  "version": "v0.39"
+  "version": "v0.40"
 }

--- a/src/Contracts/Entities/CustomerInterface.php
+++ b/src/Contracts/Entities/CustomerInterface.php
@@ -8,6 +8,11 @@ use Doctrine\Common\Collections\Collection;
 
 interface CustomerInterface extends UuidEntityInterface, CoreEntityInterface
 {
+    final public const GROUP_UPDATE = 'group_update';
+    final public const DEFAULT_BASE_LAYER_URL = 'https://sgx.geodatenzentrum.de/wms_basemapde';
+    final public const DEFAULT_BASE_LAYER_LAYERS = 'de_basemapde_web_raster_farbe';
+    final public const DEFAULT_MAP_ATTRIBUTION = '© basemap.de / BKG ({currentYear})';
+
     public function setId(string $id);
 
     /**


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-1917/Basemap-wird-nicht-per-Default-auf-Startseitenkarte-bei-neuem-Mandanten-eingetragen

Description:
This is the correct place for these constants to live I think.
Moved already existing constant from customer to its interface as well.

related PR:
https://github.com/demos-europe/demosplan-core/pull/3680