### PR TITLE
Update return type of a method in ExcelImporterHandleImportedTagsRecordsEventInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## UNRELEASED
+- update return type of getRecords in ExcelImporterHandleImportedTagsRecordsEventInterface
 
 ## v0.51 (2025-04-04)
 - add OrgaServiceInterface

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
     "symfony/var-dumper": "5.*.*",
     "symfony/var-exporter": "5.*.*",
     "symfony/yaml": "5.*.*",
-    "illuminate/collections": "^10.48"
+    "illuminate/collections": "^10.48",
+    "league/csv": "^9.18"
   },
   "require-dev": {
     "composer/composer": "^2.1",

--- a/src/Contracts/Events/ExcelImporterHandleImportedTagsRecordsEventInterface.php
+++ b/src/Contracts/Events/ExcelImporterHandleImportedTagsRecordsEventInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Events;
 
-use IteratorIterator;
+use League\Csv\MapIterator;
 
 interface ExcelImporterHandleImportedTagsRecordsEventInterface
 {
@@ -15,6 +15,6 @@ interface ExcelImporterHandleImportedTagsRecordsEventInterface
 
     public function setTags(array $tags): void;
 
-    public function getRecords(): IteratorIterator;
+    public function getRecords(): MapIterator;
 
 }


### PR DESCRIPTION
Tickt: https://demoseurope.youtrack.cloud/issue/DPLAN-15506
Description: the return type should be MapIterator not arrayIterator
https://github.com/demos-europe/demosplan-core/pull/4580