### PR TITLE
feat DPLAN-17308: add deleteFile to FileServiceInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## UNRELEASED
+- add `FileServiceInterface::deleteFile()` method for deleting files physically and from database
+
 ## v0.65 (2026-01-23)
 - add `FileServiceInterface::saveBinaryFileContent()` method for saving binary file content directly
 

--- a/src/Contracts/FileServiceInterface.php
+++ b/src/Contracts/FileServiceInterface.php
@@ -6,6 +6,7 @@ namespace DemosEurope\DemosplanAddon\Contracts;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\FileInterface;
 use DemosEurope\DemosplanAddon\Contracts\ValueObject\FileInfoInterface;
+use Exception;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Throwable;
 
@@ -75,6 +76,17 @@ interface FileServiceInterface
      * @throws FileException
      */
     public function checkMimeTypeAllowed($mimeType, $temporaryFilePath);
+
+    /**
+     * Delete a file physically from storage and remove its database record.
+     *
+     * @param string $hash The file hash or ID (_f_ident)
+     *
+     * @return bool True on successful deletion, false otherwise
+     *
+     * @throws Exception
+     */
+    public function deleteFile(string $hash): bool;
 
     /**
      * Save file from binary content (e.g., already decoded base64 content).


### PR DESCRIPTION
Ticket: [DPLAN-17308](https://demoseurope.youtrack.cloud/issue/DPLAN-17308)

## Summary
Adds `deleteFile(string $hash): bool` to `FileServiceInterface` so addons can delete files without depending on the concrete `FileService` class from demosplan core.

## Changes
- Add `deleteFile()` method to `FileServiceInterface`
- Add changelog entry

## Technical Details
The concrete `FileService::deleteFile()` already exists in demosplan core and deletes the file physically from storage and removes the database record. This change exposes that method through the interface contract so addons (e.g. `demosplan-addon-xbeteiligung-async`) can call it via the interface without bypassing the type system.