### PR TITLE
feat DPLAN-17308: extend ElementsServiceInterface with element management methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## UNRELEASED
+- extend `ElementsServiceInterface` with `getElementsAdminList()`, `getElementObject()` and `addElement()` methods
 
 ## v0.66 (2026-02-20)
 - add `FileServiceInterface::deleteFile()` method for deleting files physically and from database

--- a/src/Contracts/Services/ElementsServiceInterface.php
+++ b/src/Contracts/Services/ElementsServiceInterface.php
@@ -4,7 +4,31 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Services;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\ElementsInterface;
+use Exception;
+
 interface ElementsServiceInterface
 {
+    /**
+     * Returns all non-deleted elements for a procedure, ordered for admin display.
+     *
+     * @return ElementsInterface[]
+     *
+     * @throws Exception
+     */
+    public function getElementsAdminList(string $procedureId): array;
 
+    /**
+     * Returns a single element by ID, or null if not found.
+     *
+     * @throws Exception
+     */
+    public function getElementObject(string $id): ?ElementsInterface;
+
+    /**
+     * Creates a new element and returns the persisted data array, or null on failure.
+     *
+     * @throws Exception
+     */
+    public function addElement(array $data): ?array;
 }


### PR DESCRIPTION
Ticket: [DPLAN-17308](https://demoseurope.youtrack.cloud/issue/DPLAN-17308)

## Summary
Extends the currently empty `ElementsServiceInterface` with the methods that are already provided by the concrete `ElementsService` implementation in demosplan core.

## Changes
- Add `getElementsAdminList()` to retrieve all non-deleted elements for a procedure
- Add `getElementObject()` to retrieve a single element by ID
- Add `addElement()` to create a new element
- Add changelog entry

## Technical Details
`ElementsServiceInterface` was empty, which meant addons could not call any methods on it via the interface. This prevented proper mocking in tests and forced the use of hand-rolled test doubles. With these methods declared in the interface, addons can use `ElementsService` correctly through the contract.