### PR TITLE
feature (refs DPLAN-17436) add SegmentXlsxExportColumnsEventInterface and SegmentXlsxExportDataEventInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+## v0.68 (2026-03-03)
+- add SegmentXlsxExportColumnsEventInterface and SegmentXlsxExportDataEventInterface
+
 ## v0.67 (2026-02-20)
 - extend `ElementsServiceInterface` with `getElementsAdminList()`, `getElementObject()` and `addElement()` methods
 

--- a/composer.json
+++ b/composer.json
@@ -63,5 +63,5 @@
   "scripts": {
     "phpstan": "phpstan analyse"
   },
-  "version": "v0.67"
+  "version": "v0.68"
 }

--- a/src/Contracts/Events/SegmentXlsxExportColumnsEventInterface.php
+++ b/src/Contracts/Events/SegmentXlsxExportColumnsEventInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DemosEurope\DemosplanAddon\Contracts\Events;
+
+/**
+ * Dispatched once before the segment XLSX export is built.
+ * Subscribers may replace or extend the column definitions array.
+ * Without any subscriber the default tagNames/topicNames columns remain unchanged.
+ */
+interface SegmentXlsxExportColumnsEventInterface
+{
+    public function getColumnsDefinition(): array;
+
+    public function setColumnsDefinition(array $columnsDefinition): void;
+}

--- a/src/Contracts/Events/SegmentXlsxExportDataEventInterface.php
+++ b/src/Contracts/Events/SegmentXlsxExportDataEventInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DemosEurope\DemosplanAddon\Contracts\Events;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\SegmentInterface;
+
+/**
+ * Dispatched once per segment during the XLSX export data build.
+ * Subscribers may enrich the export data array, e.g. by adding topicalTagNames
+ * and nonTopicalTagNames keys.
+ * Without any subscriber the export data remains unchanged.
+ */
+interface SegmentXlsxExportDataEventInterface
+{
+    public function getSegment(): SegmentInterface;
+
+    public function getExportData(): array;
+
+    public function setExportData(array $exportData): void;
+}


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-17436/BE-Synopse-Excel-Export-Unterscheidung-nach-Schlagwortarten

Description:
add SegmentXlsxExportColumnsEventInterface and SegmentXlsxExportDataEventInterface