### PR TITLE
feat(DPLAN-17496): add RecommendationVersion to contract layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## UNRELEASED
+- add RecommendationVersionInterface, RecommendationVersionPath, and getRecommendationVersions() to StatementInterface
 
 ## v0.68 (2026-03-03)
 - add SegmentXlsxExportColumnsEventInterface and SegmentXlsxExportDataEventInterface

--- a/src/Contracts/Entities/RecommendationVersionInterface.php
+++ b/src/Contracts/Entities/RecommendationVersionInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DemosEurope\DemosplanAddon\Contracts\Entities;
+
+use DateTime;
+
+interface RecommendationVersionInterface
+{
+    /**
+     * Returns the version ID.
+     *
+     * Note: the collection returned by {@see StatementInterface::getRecommendationVersions()}
+     * includes a virtual "current" version whose ID follows the pattern 'virtual-{statementId}'
+     * instead of a real UUID. Consumers should account for this when processing IDs.
+     */
+    public function getId(): ?string;
+
+    public function getStatement(): StatementInterface;
+
+    public function getVersionNumber(): int;
+
+    public function getRecommendationText(): string;
+
+    public function getCreatedAt(): ?DateTime;
+}

--- a/src/Contracts/Entities/StatementInterface.php
+++ b/src/Contracts/Entities/StatementInterface.php
@@ -599,6 +599,13 @@ interface StatementInterface extends UuidEntityInterface, CoreEntityInterface
     public function getRecommendation(): string;
 
     /**
+     * Returns all recommendation versions including a virtual "current" version.
+     *
+     * @return Collection<int, RecommendationVersionInterface>
+     */
+    public function getRecommendationVersions(): Collection;
+
+    /**
      * @param string $additionalRecommendationParagraphText
      */
     public function addRecommendationParagraph($additionalRecommendationParagraphText): StatementInterface;

--- a/src/EntityPath/Paths.php
+++ b/src/EntityPath/Paths.php
@@ -625,4 +625,10 @@ class Paths
 	{
 		return PlatformFaqPath::startPath();
 	}
+
+
+	public static function recommendationVersion(): RecommendationVersionPath
+	{
+		return RecommendationVersionPath::startPath();
+	}
 }

--- a/src/EntityPath/RecommendationVersionPath.php
+++ b/src/EntityPath/RecommendationVersionPath.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DemosEurope\DemosplanAddon\EntityPath;
+
+use EDT\PathBuilding\End;
+use EDT\PathBuilding\PropertyAutoPathInterface;
+use EDT\PathBuilding\PropertyAutoPathTrait;
+
+/**
+ * @property-read End $id
+ * @property-read End $versionNumber
+ * @property-read End $recommendationText
+ * @property-read End $createdAt
+ * @property-read StatementPath $statement
+ */
+class RecommendationVersionPath implements PropertyAutoPathInterface
+{
+	use PropertyAutoPathTrait;
+}

--- a/src/EntityPath/StatementPath.php
+++ b/src/EntityPath/StatementPath.php
@@ -91,6 +91,7 @@ use EDT\PathBuilding\PropertyAutoPathTrait;
  * @property-read End $piSegmentsProposalResourceUrl
  * @property-read ProcedurePersonPath $similarStatementSubmitters
  * @property-read End $anonymous
+ * @property-read RecommendationVersionPath $recommendationVersions
  */
 class StatementPath implements PropertyAutoPathInterface
 {


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-17496/BE-Versionsnummer-der-Erwiderung-anlegen

Description:
add RecommendationVersion to contract layer
- Add RecommendationVersionInterface with virtual ID documentation
- Add getRecommendationVersions() to StatementInterface
- Add RecommendationVersionPath and register in Paths
- Add recommendationVersions to StatementPath