### PR TITLE
fix: return HTTP 500 for PHP Error in APIController::handleApiError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## UNRELEASED
+- return HTTP 500 instead of 400 for PHP `Error` throwables in `APIController::handleApiError()`
+
 ## v0.71 (2026-05-19)
 - upgrade to edt 0.28 to support attributes instead of annotations
 

--- a/src/Controller/APIController.php
+++ b/src/Controller/APIController.php
@@ -32,6 +32,7 @@ use EDT\Wrapping\Contracts\PropertyAccessException;
 use EDT\Wrapping\Contracts\TypeRetrievalAccessException;
 use EDT\Wrapping\TypeProviders\PrefilledTypeProvider;
 use EDT\Wrapping\Utilities\SchemaPathProcessor;
+use Error;
 use Exception;
 use InvalidArgumentException;
 use JsonSchema\Exception\ResourceNotFoundException;
@@ -242,6 +243,10 @@ abstract class APIController extends AbstractController
                 case in_array(DuplicateInternIdExceptionImterface::class, $exceptionParentInterfaces, true):
                     $status = Response::HTTP_BAD_REQUEST;
                     $message = 'error.unique.procedure.internid';
+                    break;
+                case $exception instanceof Error:
+                    $status = Response::HTTP_INTERNAL_SERVER_ERROR;
+                    $message = 'error.api.generic';
                     break;
                 default:
                     $message = 'error.api.generic';


### PR DESCRIPTION
## Summary

`APIController::handleApiError()` defaulted unknown throwables to HTTP 400 (Bad Request). With Symfony's `handle_all_throwables: true` (enabled in core PR demos-europe/demosplan-core#6268), PHP `Error` instances (`TypeError`, `ParseError`, `OutOfMemoryError`, …) now also flow through the `kernel.exception` listener and into `handleApiError()`. Returning 400 misleads clients into thinking they sent bad data when the server actually crashed.

Add an explicit case mapping `Error` to HTTP 500. Logging is unchanged — every throwable is already logged at `error` level with full exception + backtrace at the top of `handleApiError()`.

## Test plan

- [ ] CI green
- [ ] Manual: trigger a `TypeError` in an API controller in a core checkout that has handle_all_throwables enabled; response is `500` with `error.api.generic`