### PR TITLE
fix: declare nullable parameters explicitly to silence deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## UNRELEASED
+### Fixed
+- Declare nullable parameters explicitly (`?Type $param = null`) across the contracts and API-request
+  layer to silence the PHP 8.4 / Symfony "implicitly marking parameter as nullable" deprecations.
 
 ## v0.73 (2026-05-27)
 - Adds API Platform bridge infrastructure to demosplan-addon, enabling gradual migration from EDT to API Platform.

--- a/src/Contracts/CurrentUserInterface.php
+++ b/src/Contracts/CurrentUserInterface.php
@@ -15,7 +15,7 @@ interface CurrentUserInterface
      */
     public function getUser(): UserInterface;
 
-    public function setUser(UserInterface $user, CustomerInterface $customer = null): void;
+    public function setUser(UserInterface $user, ?CustomerInterface $customer = null): void;
 
     public function getPermissions(): PermissionsInterface;
 

--- a/src/Contracts/Entities/ProcedureSettingsInterface.php
+++ b/src/Contracts/Entities/ProcedureSettingsInterface.php
@@ -344,7 +344,7 @@ interface ProcedureSettingsInterface extends UuidEntityInterface, CoreEntityInte
      *
      * @return ProcedureSettingsInterface
      */
-    public function setProcedure(ProcedureInterface $procedure = null);
+    public function setProcedure(?ProcedureInterface $procedure = null);
 
     /**
      * Get p.

--- a/src/Contracts/Entities/StatementVersionFieldInterface.php
+++ b/src/Contracts/Entities/StatementVersionFieldInterface.php
@@ -127,7 +127,7 @@ interface StatementVersionFieldInterface extends UuidEntityInterface
      *
      * @return StatementVersionFieldInterface
      */
-    public function setStatement(StatementInterface $statement = null);
+    public function setStatement(?StatementInterface $statement = null);
 
     /**
      * Get st.

--- a/src/Contracts/Entities/UserInterface.php
+++ b/src/Contracts/Entities/UserInterface.php
@@ -530,14 +530,14 @@ interface UserInterface extends SecurityUserInterface, UuidEntityInterface, Pass
      *
      * @return Collection<int, RoleInterface>
      */
-    public function getDplanroles(CustomerInterface $customer = null): Collection;
+    public function getDplanroles(?CustomerInterface $customer = null): Collection;
 
     /**
      * Returns an array of the code of roles the user has with a specified customer (current is default).
      *
      * @return string[]
      */
-    public function getDplanRolesArray(CustomerInterface $customer = null): array;
+    public function getDplanRolesArray(?CustomerInterface $customer = null): array;
 
     /**
      * This function is needed to clear the roles cache to prevent roles being still present
@@ -593,7 +593,7 @@ interface UserInterface extends SecurityUserInterface, UuidEntityInterface, Pass
      *
      * @param string $role
      */
-    public function hasRole($role, CustomerInterface $customer = null): bool;
+    public function hasRole($role, ?CustomerInterface $customer = null): bool;
 
     public function hasAnyOfRoles(array $roles, ?CustomerInterface $customer): bool;
 

--- a/src/Contracts/Exceptions/AddonContentMandatoryFieldsException.php
+++ b/src/Contracts/Exceptions/AddonContentMandatoryFieldsException.php
@@ -12,7 +12,7 @@ class AddonContentMandatoryFieldsException extends Exception
     /** @var array<int, string> */
     private $mandatoryFieldMessages;
 
-    public function __construct(array $mandatoryFieldMessages, $message = '', $code = 0, Throwable $previous = null)
+    public function __construct(array $mandatoryFieldMessages, $message = '', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->mandatoryFieldMessages = $mandatoryFieldMessages;

--- a/src/Contracts/ResourceType/ResourceTypeServiceInterface.php
+++ b/src/Contracts/ResourceType/ResourceTypeServiceInterface.php
@@ -19,5 +19,5 @@ interface ResourceTypeServiceInterface
      *
      * @see https://symfony.com/doc/4.4/validation/groups.html
      */
-    public function validateObject(object $entity, array $groups = null): void;
+    public function validateObject(object $entity, ?array $groups = null): void;
 }

--- a/src/Controller/APIController.php
+++ b/src/Controller/APIController.php
@@ -206,7 +206,7 @@ abstract class APIController extends AbstractController
      *
      * Also add messages to message bag.
      */
-    public function handleApiError(Throwable $exception = null): APIResponse
+    public function handleApiError(?Throwable $exception = null): APIResponse
     {
         $status = Response::HTTP_BAD_REQUEST;
         $message = '';

--- a/src/Logic/ApiRequest/DoctrineOrmPartialDTOProvider.php
+++ b/src/Logic/ApiRequest/DoctrineOrmPartialDTOProvider.php
@@ -52,7 +52,7 @@ class DoctrineOrmPartialDTOProvider extends DoctrineOrmEntityProvider
      *
      * @throws MappingException
      */
-    public function getObjects(array $conditions, array $sortMethods = [], int $offset = 0, int $limit = null): iterable
+    public function getObjects(array $conditions, array $sortMethods = [], int $offset = 0, ?int $limit = null): iterable
     {
         $queryBuilder = $this->generateQueryBuilder($conditions, $sortMethods, $offset, $limit);
         $this->replaceSelect($queryBuilder);

--- a/src/Logic/ApiRequest/FluentRepository.php
+++ b/src/Logic/ApiRequest/FluentRepository.php
@@ -104,7 +104,7 @@ abstract class FluentRepository extends ServiceEntityRepository implements Repos
      *
      * @return array<int,TEntity>
      */
-    public function getEntities(array $conditions, array $sortMethods, int $offset = 0, int $limit = null): array
+    public function getEntities(array $conditions, array $sortMethods, int $offset = 0, ?int $limit = null): array
     {
         $pagination = 0 !== $offset || null !== $limit
             ? new OffsetPagination($offset, $limit ?? PHP_INT_MAX)


### PR DESCRIPTION
## What

Adds the explicit `?` to typed parameters that default to `null` across the contracts and API-request layer. These implicitly-nullable signatures (`Type $param = null`) emit a *"Implicitly marking parameter as nullable is deprecated"* notice on **every request** under PHP 8.4 / Symfony.

## Files

- `Contracts/Entities/UserInterface` — `getDplanroles`, `getDplanRolesArray`, `hasRole` (`?CustomerInterface`)
- `Contracts/CurrentUserInterface::setUser` (`?CustomerInterface`)
- `Contracts/Entities/ProcedureSettingsInterface::setProcedure` (`?ProcedureInterface`)
- `Contracts/Entities/StatementVersionFieldInterface::setStatement` (`?StatementInterface`)
- `Contracts/ResourceType/ResourceTypeServiceInterface::validateObject` (`?array`)
- `Contracts/Exceptions/AddonContentMandatoryFieldsException::__construct` (`?Throwable`)
- `Controller/APIController::handleApiError` (`?Throwable`)
- `Logic/ApiRequest/FluentRepository::getEntities` (`?int`)
- `Logic/ApiRequest/DoctrineOrmPartialDTOProvider::getObjects` (`?int`)

## Risk

None. `Type $param = null` is already implicitly nullable in PHP, so the explicit `?` changes neither the accepted types nor the runtime behavior; it only makes the existing nullability explicit. Implementations that use `Type $param = null` remain signature-compatible.