### PR TITLE
feature (refs DPP-1023) add new SegmentTagsChangedEventInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## UNRELEASED
+
+- add new SegmentTagsChangedEventInterface
+- Core versions > v4.44.0 will depend on min this version
+
 ## v0.74 (2026-06-08)
 ### Fixed
 - Declare nullable parameters explicitly (`?Type $param = null`) across the contracts and API-request

--- a/src/Contracts/Events/SegmentTagsChangedEventInterface.php
+++ b/src/Contracts/Events/SegmentTagsChangedEventInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DemosEurope\DemosplanAddon\Contracts\Events;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
+
+interface SegmentTagsChangedEventInterface
+{
+    /**
+     * @return StatementInterface[]
+     */
+    public function getStatements(): array;
+}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPP-1023

### Description
Introduce new SegmentTagsChangedEventInterface that the core versions after v4.44.0 implement.

### Linked PRs (optional)

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 