### PR TITLE
feat(refs DPLAN-18064): Add ProcedurePhaseDefinitionMarkedAsDeletedEventInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## UNRELEASED
+- add `ProcedurePhaseDefinitionMarkedAsDeletedEventInterface` so addons can listen for soft-deletion of a `ProcedurePhaseDefinition` and clean up their own related entities
 
 ## v0.75 (2026-06-11)
 - add `isLocked()` and `setLocked()` to `PlaceInterface` for the new segment lock feature (segments on workflow places with `locked=true` become read-only for users without the lock administration permission)

--- a/src/Contracts/Events/ProcedurePhaseDefinitionMarkedAsDeletedEventInterface.php
+++ b/src/Contracts/Events/ProcedurePhaseDefinitionMarkedAsDeletedEventInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\Contracts\Events;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedurePhaseDefinitionInterface;
+
 interface ProcedurePhaseDefinitionMarkedAsDeletedEventInterface
 {
-    public function getPhaseDefinitionId(): string;
+    public function getPhaseDefinition(): ProcedurePhaseDefinitionInterface;
 }

--- a/src/Contracts/Events/ProcedurePhaseDefinitionMarkedAsDeletedEventInterface.php
+++ b/src/Contracts/Events/ProcedurePhaseDefinitionMarkedAsDeletedEventInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DemosEurope\DemosplanAddon\Contracts\Events;
+
+interface ProcedurePhaseDefinitionMarkedAsDeletedEventInterface
+{
+    public function getPhaseDefinitionId(): string;
+}


### PR DESCRIPTION
Ticket: [DPLAN-18064](https://demoseurope.youtrack.cloud/issue/DPLAN-18064/NEU-ADO-52178-Loschen-von-custom-Verfahrensschritten)

## Summary

Adds `ProcedurePhaseDefinitionMarkedAsDeletedEventInterface` to `Contracts/Events` so addons can subscribe to the soft-deletion of a `ProcedurePhaseDefinition` and clean up their own related entities (e.g. mapping tables referencing the deleted definition).