### PR TITLE
F 576 nullable drafts list json setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## UNRELEASED
+- widen `StatementInterface::setDraftsListJson()` parameter from `string` to `?string` to match the nullable `drafts_info_json` column
+
 
 ## v0.77 (2026-06-30)
 ### Fixed

--- a/src/Contracts/Entities/StatementInterface.php
+++ b/src/Contracts/Entities/StatementInterface.php
@@ -1307,7 +1307,7 @@ interface StatementInterface extends UuidEntityInterface, CoreEntityInterface
      */
     public function getParagraphParentTitleOrDocumentParentTitle(): ?string;
 
-    public function setDraftsListJson(string $json): void;
+    public function setDraftsListJson(?string $json): void;
 
     /**
      * @return string May be empty if none was set yet


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-576

Description: 
Widen StatementInterface::setDraftsListJson() parameter from string to ?string: The drafts_info_json column is nullable, so the setter contract must permit null. Core needs to reset a stored draft to null (to discard an unconvertible legacy segment draft); the interface previously forbade it.
